### PR TITLE
Feat/arc ingest command handler support

### DIFF
--- a/pkg/core/engine/contract.go
+++ b/pkg/core/engine/contract.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	"github.com/4chain-ag/go-overlay-services/pkg/core/gasp/core"
+	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/overlay"
 	"github.com/bsv-blockchain/go-sdk/overlay/lookup"
+	"github.com/bsv-blockchain/go-sdk/transaction"
 )
 
 // OverlayEngineProvider defines the contract for the overlay engine.
@@ -23,4 +25,5 @@ type OverlayEngineProvider interface {
 	ListLookupServiceProviders() map[string]*overlay.MetaData
 	GetDocumentationForLookupServiceProvider(provider string) (string, error)
 	GetDocumentationForTopicManager(provider string) (string, error)
+	HandleNewMerkleProof(ctx context.Context, txid *chainhash.Hash, proof *transaction.MerklePath) error
 }

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -179,6 +179,7 @@ func New(opts ...HTTPOption) (*HTTP, error) {
 	http.Router = v1
 
 	// Non-Admin:
+	v1.Post("/arc-ingest", SafeHandler(http.api.Commands.ArcIngestHandler.Handle))
 	v1.Get("/getDocumentationForTopicManager", SafeHandler(http.api.Queries.TopicManagerDocumentationHandler.Handle))
 	v1.Get("/getDocumentationForLookupServiceProvider", SafeHandler(http.api.Queries.LookupServiceDocumentationHandler.Handle))
 	v1.Get("/listLookupServiceProviders", SafeHandler(http.api.Queries.LookupServicesListHandler.Handle))

--- a/pkg/server/internal/app/app.go
+++ b/pkg/server/internal/app/app.go
@@ -17,7 +17,6 @@ type Commands struct {
 	RequestSyncResponseHandler    *commands.RequestSyncResponseHandler
 	LookupQuestionHandler         *commands.LookupQuestionHandler
 	ArcIngestHandler              *commands.ArcIngestHandler
-
 }
 
 // Queries aggregate all the supported queries by the overlay API.
@@ -101,7 +100,6 @@ func initCommands(provider engine.OverlayEngineProvider) (*Commands, error) {
 		RequestSyncResponseHandler:    requestSyncRespHandler,
 		LookupQuestionHandler:         lookupQuestionHandler,
 		ArcIngestHandler:              arcIngestHandler,
-
 	}, nil
 }
 

--- a/pkg/server/internal/app/app.go
+++ b/pkg/server/internal/app/app.go
@@ -16,6 +16,8 @@ type Commands struct {
 	RequestForeignGASPNodeHandler *commands.RequestForeignGASPNodeHandler
 	RequestSyncResponseHandler    *commands.RequestSyncResponseHandler
 	LookupQuestionHandler         *commands.LookupQuestionHandler
+	ArcIngestHandler              *commands.ArcIngestHandler
+
 }
 
 // Queries aggregate all the supported queries by the overlay API.
@@ -86,6 +88,11 @@ func initCommands(provider engine.OverlayEngineProvider) (*Commands, error) {
 		return nil, fmt.Errorf("LookupQuestionHandler: %w", err)
 	}
 
+	arcIngestHandler, err := commands.NewArcIngestHandler(provider)
+	if err != nil {
+		return nil, fmt.Errorf("ArcIngestHandler: %w", err)
+	}
+
 	return &Commands{
 		SubmitTransactionHandler:      submitHandler,
 		SyncAdvertismentsHandler:      syncAdsHandler,
@@ -93,6 +100,8 @@ func initCommands(provider engine.OverlayEngineProvider) (*Commands, error) {
 		RequestForeignGASPNodeHandler: requestGASPHandler,
 		RequestSyncResponseHandler:    requestSyncRespHandler,
 		LookupQuestionHandler:         lookupQuestionHandler,
+		ArcIngestHandler:              arcIngestHandler,
+
 	}, nil
 }
 

--- a/pkg/server/internal/app/commands/arc_ingest.go
+++ b/pkg/server/internal/app/commands/arc_ingest.go
@@ -125,8 +125,6 @@ type ArcIngestHandler struct {
 	responseTimeout  time.Duration
 }
 
-// decode reads and decodes the request body into the provided destination
-// struct. It ensures the request body size is within the allowed limit.
 func (h *ArcIngestHandler) decode(body io.Reader, dst *ArcIngestRequest) error {
 	reader := jsonutil.LimitedBodyReader{
 		Body:      body,

--- a/pkg/server/internal/app/commands/arc_ingest.go
+++ b/pkg/server/internal/app/commands/arc_ingest.go
@@ -38,10 +38,10 @@ var (
 
 	// ErrMerkleProofProcessingTimeout is returned when Merkle proof processing times out.
 	ErrMerkleProofProcessingTimeout = errors.New("Merkle proof processing timed out")
-	
+
 	// ErrMerkleProofProcessingCanceled is returned when Merkle proof processing is canceled.
 	ErrMerkleProofProcessingCanceled = errors.New("Merkle proof processing canceled")
-	
+
 	// ErrMerkleProofProcessingFailed is returned when Merkle proof processing fails for an unknown reason.
 	ErrMerkleProofProcessingFailed = errors.New("Internal server error occurred during processing")
 )
@@ -282,7 +282,7 @@ func NewArcIngestHandler(provider NewMerkleProofProvider, opts ...ArcIngestHandl
 // indicating that the transaction status has been successfully updated.
 func NewSuccessArcIngestHandlerResponse() ArcIngestHandlerResponse {
 	return ArcIngestHandlerResponse{
-		Status: "success",
+		Status:  "success",
 		Message: "Transaction status updated",
 	}
 }

--- a/pkg/server/internal/app/commands/arc_ingest.go
+++ b/pkg/server/internal/app/commands/arc_ingest.go
@@ -17,21 +17,21 @@ import (
 var (
 	// ErrInvalidTxIDFormat is returned when the transaction ID is not in a valid format (e.g., not hexadecimal).
 	ErrInvalidTxIDFormat = errors.New("invalid transaction ID format")
-	
+
 	// ErrInvalidTxIDLength is returned when the transaction ID does not match the expected length (typically 64 characters for a SHA-256 hash).
 	ErrInvalidTxIDLength = errors.New("invalid transaction ID length")
 
 	// ErrInvalidMerklePathFormat is returned when the Merkle path is malformed or does not conform to the expected structure.
 	ErrInvalidMerklePathFormat = errors.New("invalid Merkle path format")
-	
+
 	// ErrMissingRequiredRequestFieldsDefinition is returned when the request body is missing
 	// required fields, such as the transaction ID and Merkle path.
 	ErrMissingRequiredRequestFieldsDefinition = errors.New("missing required fields: txid, merkle path")
-	
+
 	// ErrMissingRequiredTxIDFieldDefinition is returned when the request body is missing
 	// the required transaction ID field.
 	ErrMissingRequiredTxIDFieldDefinition = errors.New("missing required field: txid")
-	
+
 	// ErrMissingRequiredMerklePathFieldDefinition is returned when the request body is missing
 	// the required Merkle path field.
 	ErrMissingRequiredMerklePathFieldDefinition = errors.New("missing required field: merkle path")
@@ -147,7 +147,7 @@ func (h *ArcIngestHandler) buildHandleNewMerkleProofArguments(body io.Reader) (c
 	if err != nil {
 		return chainhash.Hash{}, nil, err
 	}
-	
+
 	hash, err := chainhash.NewHashFromHex(dst.TxID)
 	if err != nil {
 		return chainhash.Hash{}, nil, errors.Join(err, ErrInvalidTxIDFormat)
@@ -156,8 +156,8 @@ func (h *ArcIngestHandler) buildHandleNewMerkleProofArguments(body io.Reader) (c
 	if len(dst.TxID) != chainhash.MaxHashStringSize {
 		return chainhash.Hash{}, nil, ErrInvalidTxIDLength
 	}
-	
-	merklePath, err := dst.MerklePathStruct() 
+
+	merklePath, err := dst.MerklePathStruct()
 	if err != nil {
 		return chainhash.Hash{}, nil, err
 	}
@@ -178,10 +178,10 @@ func (h *ArcIngestHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		h.handleMerkleProofArgumentError(w, err)
 		return
 	}
-	
+
 	ctx, cancel := context.WithTimeout(r.Context(), h.responseTimeout)
 	defer cancel()
-	
+
 	err = h.provider.HandleNewMerkleProof(ctx, &txIDHash, merklePath)
 	h.handleMerkleProofResult(w, err)
 }
@@ -216,19 +216,19 @@ func (h *ArcIngestHandler) handleMerkleProofArgumentError(w http.ResponseWriter,
 		errors.Is(err, jsonutil.JSONDecoderFailure):
 		slog.Error(fmt.Sprintf("[ArcIngest] Request body read/decode error: %v", err))
 		jsonutil.SendHTTPResponse(w, http.StatusInternalServerError, NewInternalFailureArcIngestHandlerResponse())
-	
+
 	case errors.Is(err, ErrInvalidMerklePathFormat):
 		slog.Error(fmt.Sprintf("[ArcIngest] Invalid Merkle path format: %v", err))
 		jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(ErrInvalidMerklePathFormat.Error()))
-	
+
 	case errors.Is(err, ErrInvalidTxIDFormat):
 		slog.Error(fmt.Sprintf("[ArcIngest] Invalid transaction ID format: %v", err))
 		jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(ErrInvalidTxIDFormat.Error()))
-	
+
 	case errors.Is(err, ErrInvalidTxIDLength):
 		slog.Error(fmt.Sprintf("[ArcIngest] Invalid transaction ID length: %v", err))
 		jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(ErrInvalidTxIDLength.Error()))
-	
+
 	default:
 		slog.Error(fmt.Sprintf("[ArcIngest] Bad request error: %v", err))
 		jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(err.Error()))

--- a/pkg/server/internal/app/commands/arc_ingest.go
+++ b/pkg/server/internal/app/commands/arc_ingest.go
@@ -16,450 +16,254 @@ import (
 )
 
 var (
-
 	// ErrInvalidTxIDFormat is returned when the transaction ID is not in a valid format (e.g., not hexadecimal).
-
 	ErrInvalidTxIDFormat = errors.New("invalid transaction ID format")
-
 	// ErrInvalidTxIDLength is returned when the transaction ID does not match the expected length (typically 64 characters for a SHA-256 hash).
-
 	ErrInvalidTxIDLength = errors.New("invalid transaction ID length")
-
 	// ErrInvalidMerklePathFormat is returned when the Merkle path is malformed or does not conform to the expected structure.
-
 	ErrInvalidMerklePathFormat = errors.New("invalid Merkle path format")
-
 	// ErrMissingRequiredRequestFieldsDefinition is returned when the request body is missing
-
 	// required fields, such as the transaction ID and Merkle path.
-
 	ErrMissingRequiredRequestFieldsDefinition = errors.New("missing required fields: txid, merkle path")
-
 	// ErrMissingRequiredTxIDFieldDefinition is returned when the request body is missing
-
 	// the required transaction ID field.
-
 	ErrMissingRequiredTxIDFieldDefinition = errors.New("missing required field: txid")
-
 	// ErrMissingRequiredMerklePathFieldDefinition is returned when the request body is missing
-
 	// the required Merkle path field.
-
 	ErrMissingRequiredMerklePathFieldDefinition = errors.New("missing required field: merkle path")
 )
 
 // ArcIngestHandlerResponse represents the response format for the ArcIngestHandler,
-
 // containing the status of the operation and a message providing additional context.
-
 type ArcIngestHandlerResponse struct {
 	Status string `json:"status"` // The status of the request (e.g., "success", "error")
-
 	Message string `json:"message"` // A message providing additional information about the result
-
 }
 
 // ArcIngestRequest defines the expected structure for the ARC ingest request body,
-
 // containing the transaction ID, Merkle path, and block height. This structure
-
 // is used to validate and process incoming ARC ingest requests.
-
 type ArcIngestRequest struct {
 	TxID string `json:"txid"` // Transaction ID in hexadecimal format
-
 	MerklePath string `json:"merklePath"` // Merkle path as a hex string
-
 	BlockHeight uint32 `json:"blockHeight"` // Block height associated with the Merkle path
-
 }
 
 // IsMerklePathEmpty checks if the MerklePath field is empty, indicating missing data.
-
 func (r *ArcIngestRequest) IsMerklePathEmpty() bool {
-
 	return r.MerklePath == ""
-
 }
 
 // IsTxIDEmpty checks if the TxID field is empty, indicating missing data.
-
 func (r *ArcIngestRequest) IsTxIDEmpty() bool {
-
 	return r.TxID == ""
-
 }
 
 // IsEmpty checks if all fields in the ArcIngestRequest are zero or empty values,
-
 // signifying an invalid or incomplete request.
-
 func (r *ArcIngestRequest) IsEmpty() bool {
-
 	return r.TxID == "" && r.MerklePath == "" && r.BlockHeight == 0
-
 }
 
 // Validate checks if all required fields are present and valid. It returns an
-
 // error if any of the required fields are missing or improperly formatted.
-
 func (r *ArcIngestRequest) Validate() error {
-
 	if r.IsEmpty() {
-
 		return ErrMissingRequiredRequestFieldsDefinition
-
 	}
-
 	if r.IsTxIDEmpty() {
-
 		return ErrMissingRequiredTxIDFieldDefinition
-
 	}
-
 	if r.IsMerklePathEmpty() {
-
 		return ErrMissingRequiredMerklePathFieldDefinition
-
 	}
-
 	return nil
-
 }
 
 // MerklePathStruct parses the MerklePath hex string and returns the Merkle path
-
 // structure. It also sets the associated block height on the resulting structure.
-
 func (r *ArcIngestRequest) MerklePathStruct() (*transaction.MerklePath, error) {
-
 	path, err := transaction.NewMerklePathFromHex(r.MerklePath)
-
 	if err != nil {
-
 		return nil, errors.Join(err, ErrInvalidMerklePathFormat)
-
 	}
-
 	path.BlockHeight = r.BlockHeight
-
 	return path, nil
-
 }
 
 // TxIDHash converts the transaction ID (TxID) from a hex string to a chainhash.Hash
-
 // representation. It returns an error if the string is improperly formatted or has
-
 // an invalid length.
-
 func (r *ArcIngestRequest) TxIDHash() (chainhash.Hash, error) {
-
 	bb, err := hex.DecodeString(r.TxID)
-
 	if err != nil {
-
 		return chainhash.Hash{}, errors.Join(err, ErrInvalidTxIDFormat)
-
 	}
-
 	if len(bb) != chainhash.HashSize {
-
 		return chainhash.Hash{}, ErrInvalidTxIDLength
-
 	}
-
 	var hash chainhash.Hash
-
 	copy(hash[:], bb)
-
 	return hash, nil
-
 }
 
 // NewMerkleProofProvider defines the contract for handling new Merkle proofs.
-
 // It allows the overlay engine to verify mined transactions and maintain
-
 // a chain-of-custody for transaction outputs.
-
 type NewMerkleProofProvider interface {
 	HandleNewMerkleProof(ctx context.Context, txid *chainhash.Hash, proof *transaction.MerklePath) error
 }
 
 // ArcIngestHandler orchestrates the processing of ARC ingest requests, including
-
 // validation of incoming request bodies, conversion of the data into the
-
 // appropriate format, and forwarding the data to the overlay engine for processing.
-
 type ArcIngestHandler struct {
 	provider NewMerkleProofProvider
-
 	requestBodyLimit int64
-
 	responseTimeout time.Duration
 }
 
 // decode reads and decodes the request body into the provided destination
-
 // struct. It ensures the request body size is within the allowed limit.
-
 func (h *ArcIngestHandler) decode(body io.Reader, dst *ArcIngestRequest) error {
-
 	reader := jsonutil.LimitedBodyReader{
-
 		Body: body,
-
 		ReadLimit: jsonutil.RequestBodyLimit1GB,
 	}
-
 	bb, err := reader.Read()
-
 	if err != nil {
-
 		return fmt.Errorf("body reader failure: %w", err)
-
 	}
-
 	err = jsonutil.DecodeBytes(bb, dst)
-
 	if err != nil {
-
 		return fmt.Errorf("decode bytes failure: %w", err)
-
 	}
-
 	return nil
-
 }
 
 // buildHandleNewMerkleProofArguments decodes the request body, validates the
-
 // fields, and returns the Merkle proof data (TxID and MerklePath) for further
-
 // processing by the provider.
-
 func (h *ArcIngestHandler) buildHandleNewMerkleProofArguments(body io.Reader) (chainhash.Hash, *transaction.MerklePath, error) {
-
 	var dst ArcIngestRequest
-
 	err := h.decode(body, &dst)
-
 	if err != nil {
-
 		return chainhash.Hash{}, nil, err
-
 	}
-
 	err = dst.Validate()
-
 	if err != nil {
-
 		return chainhash.Hash{}, nil, err
-
 	}
-
 	txIDHash, err := dst.TxIDHash()
-
 	if err != nil {
-
 		return chainhash.Hash{}, nil, err
-
 	}
-
 	merklePath, err := dst.MerklePathStruct()
-
 	if err != nil {
-
 		return chainhash.Hash{}, nil, err
-
 	}
-
 	return txIDHash, merklePath, nil
-
 }
 
 // Handle processes an ARC ingest request, handling the validation, converting
-
 // the request data into the correct format, and invoking the provider to handle
-
 // the new Merkle proof. It also manages timeout and error responses.
-
 func (h *ArcIngestHandler) Handle(w http.ResponseWriter, r *http.Request) {
-
 	if r.Method != http.MethodPost {
-
 		jsonutil.SendHTTPResponse(w, http.StatusMethodNotAllowed, NewFailureArcIngestHandlerResponse(ErrInvalidHTTPMethod.Error()))
-
 		return
-
 	}
-
 	txIDHash, merklePath, err := h.buildHandleNewMerkleProofArguments(r.Body)
-
 	if err != nil {
-
-		slog.Error(err.Error()) // TODO: replace with structured logging
+		slog.Error(fmt.Sprintf("[ArcIngest] Failed to build Merkle proof arguments: %v", err))
 
 		switch {
-
 		case errors.Is(err, jsonutil.ErrBodyReaderFailure),
-
 			errors.Is(err, jsonutil.JSONDecoderFailure):
-
 			jsonutil.SendHTTPResponse(w, http.StatusInternalServerError, NewInternalFailureArcIngestHandlerResponse())
-
 			return
-
 		case errors.Is(err, ErrInvalidMerklePathFormat):
-
 			jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(ErrInvalidMerklePathFormat.Error()))
-
 			return
-
 		case errors.Is(err, ErrInvalidTxIDFormat):
-
 			jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(ErrInvalidTxIDFormat.Error()))
-
 			return
-
 		default:
-
 			jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(err.Error()))
-
 			return
-
 		}
-
 	}
-
 	errCh := make(chan error, 1)
-
 	defer close(errCh)
-
 	go func() { errCh <- h.provider.HandleNewMerkleProof(r.Context(), &txIDHash, merklePath) }()
-
 	select {
-
 	case err := <-errCh:
-
 		if err == nil {
-
 			jsonutil.SendHTTPResponse(w, http.StatusOK, NewSuccessArcIngestHandlerResponse())
-
 			return
-
 		}
-
-		slog.Error(err.Error()) // TODO: replace with structured logging
+		slog.Error(fmt.Sprintf("[ArcIngest] Merkle proof processing failed: %v", err))
 
 		jsonutil.SendHTTPResponse(w, http.StatusInternalServerError, NewFailureArcIngestHandlerResponse(http.StatusText(http.StatusInternalServerError)))
-
 	case <-time.After(h.responseTimeout):
-
 		jsonutil.SendHTTPResponse(w, http.StatusGatewayTimeout, NewFailureArcIngestHandlerResponse(http.StatusText(http.StatusGatewayTimeout)))
-
 	}
-
 }
 
 // ArcIngestHandlerOption defines a function that configures an ArcIngestHandler.
-
 type ArcIngestHandlerOption func(h *ArcIngestHandler)
 
 // WithArcResponseTimeout configures the timeout duration for Merkle proof processing.
-
 func WithArcResponseTimeout(d time.Duration) ArcIngestHandlerOption {
-
 	return func(h *ArcIngestHandler) {
-
 		h.responseTimeout = d
-
 	}
-
 }
 
 // WithArcRequestBodyLimit configures the maximum allowed size for request bodies.
-
 func WithArcRequestBodyLimit(limit int64) ArcIngestHandlerOption {
-
 	return func(h *ArcIngestHandler) {
-
 		h.requestBodyLimit = limit
-
 	}
-
 }
 
 // NewArcIngestHandler creates a new instance of an ArcIngestHandler, utilizing
-
 // the provided Merkle proof provider and any optional configurations.
-
 func NewArcIngestHandler(provider NewMerkleProofProvider, opts ...ArcIngestHandlerOption) (*ArcIngestHandler, error) {
-
 	if provider == nil {
-
 		return nil, fmt.Errorf("provider is nil")
-
 	}
-
 	h := ArcIngestHandler{
-
 		provider: provider,
-
 		requestBodyLimit: jsonutil.RequestBodyLimit1GB,
-
 		responseTimeout: 10 * time.Second,
 	}
-
 	for _, opt := range opts {
-
 		opt(&h)
-
 	}
-
 	return &h, nil
-
 }
 
 // NewSuccessArcIngestHandlerResponse creates a success response for the ArcIngestHandler,
-
 // indicating that the transaction status has been successfully updated.
-
 func NewSuccessArcIngestHandlerResponse() ArcIngestHandlerResponse {
-
 	return ArcIngestHandlerResponse{Status: "success", Message: "Transaction status updated"}
-
 }
 
 // NewFailureArcIngestHandlerResponse creates a failure response for the ArcIngestHandler,
-
 // with the provided message describing the error that occurred during the process.
-
 func NewFailureArcIngestHandlerResponse(message string) ArcIngestHandlerResponse {
-
 	return ArcIngestHandlerResponse{
-
 		Status: "error",
-
 		Message: message,
 	}
-
 }
 
 // NewInternalFailureArcIngestHandlerResponse creates a failure response for the ArcIngestHandler,
-
 // indicating an internal server error, with the default error message for HTTP 500.
-
 func NewInternalFailureArcIngestHandlerResponse() ArcIngestHandlerResponse {
-
 	return ArcIngestHandlerResponse{
-
 		Status: "error",
-
 		Message: http.StatusText(http.StatusInternalServerError),
 	}
-
 }

--- a/pkg/server/internal/app/commands/arc_ingest.go
+++ b/pkg/server/internal/app/commands/arc_ingest.go
@@ -1,0 +1,291 @@
+package commands
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/4chain-ag/go-overlay-services/pkg/server/internal/app/jsonutil"
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+)
+
+var (
+	// ErrInvalidTxIDFormat is returned when the transaction ID is not in a valid format (e.g., not hexadecimal).
+	ErrInvalidTxIDFormat = errors.New("invalid transaction ID format")
+
+	// ErrInvalidTxIDLength is returned when the transaction ID does not match the expected length (typically 64 characters for a SHA-256 hash).
+	ErrInvalidTxIDLength = errors.New("invalid transaction ID length")
+
+	// ErrInvalidMerklePathFormat is returned when the Merkle path is malformed or does not conform to the expected structure.
+	ErrInvalidMerklePathFormat = errors.New("invalid Merkle path format")
+
+	// ErrMissingRequiredRequestFieldsDefinition is returned when the request body is missing
+	// required fields, such as the transaction ID and Merkle path.
+	ErrMissingRequiredRequestFieldsDefinition = errors.New("missing required fields: txid, merkle path")
+
+	// ErrMissingRequiredTxIDFieldDefinition is returned when the request body is missing
+	// the required transaction ID field.
+	ErrMissingRequiredTxIDFieldDefinition = errors.New("missing required field: txid")
+
+	// ErrMissingRequiredMerklePathFieldDefinition is returned when the request body is missing
+	// the required Merkle path field.
+	ErrMissingRequiredMerklePathFieldDefinition = errors.New("missing required field: merkle path")
+)
+
+// ArcIngestHandlerResponse represents the response format for the ArcIngestHandler,
+// containing the status of the operation and a message providing additional context.
+type ArcIngestHandlerResponse struct {
+	Status  string `json:"status"`  // The status of the request (e.g., "success", "error")
+	Message string `json:"message"` // A message providing additional information about the result
+}
+
+// ArcIngestRequest defines the expected structure for the ARC ingest request body,
+// containing the transaction ID, Merkle path, and block height. This structure
+// is used to validate and process incoming ARC ingest requests.
+type ArcIngestRequest struct {
+	TxID        string `json:"txid"`        // Transaction ID in hexadecimal format
+	MerklePath  string `json:"merklePath"`  // Merkle path as a hex string
+	BlockHeight uint32 `json:"blockHeight"` // Block height associated with the Merkle path
+}
+
+// IsMerklePathEmpty checks if the MerklePath field is empty, indicating missing data.
+func (r *ArcIngestRequest) IsMerklePathEmpty() bool {
+	return r.MerklePath == ""
+}
+
+// IsTxIDEmpty checks if the TxID field is empty, indicating missing data.
+func (r *ArcIngestRequest) IsTxIDEmpty() bool {
+	return r.TxID == ""
+}
+
+// IsEmpty checks if all fields in the ArcIngestRequest are zero or empty values,
+// signifying an invalid or incomplete request.
+func (r *ArcIngestRequest) IsEmpty() bool {
+	return r.TxID == "" && r.MerklePath == "" && r.BlockHeight == 0
+}
+
+// Validate checks if all required fields are present and valid. It returns an
+// error if any of the required fields are missing or improperly formatted.
+func (r *ArcIngestRequest) Validate() error {
+	if r.IsEmpty() {
+		return ErrMissingRequiredRequestFieldsDefinition
+	}
+	if r.IsTxIDEmpty() {
+		return ErrMissingRequiredTxIDFieldDefinition
+	}
+	if r.IsMerklePathEmpty() {
+		return ErrMissingRequiredMerklePathFieldDefinition
+	}
+
+	return nil
+}
+
+// MerklePathStruct parses the MerklePath hex string and returns the Merkle path
+// structure. It also sets the associated block height on the resulting structure.
+func (r *ArcIngestRequest) MerklePathStruct() (*transaction.MerklePath, error) {
+	path, err := transaction.NewMerklePathFromHex(r.MerklePath)
+	if err != nil {
+		return nil, errors.Join(err, ErrInvalidMerklePathFormat)
+	}
+
+	path.BlockHeight = r.BlockHeight
+	return path, nil
+}
+
+// TxIDHash converts the transaction ID (TxID) from a hex string to a chainhash.Hash
+// representation. It returns an error if the string is improperly formatted or has
+// an invalid length.
+func (r *ArcIngestRequest) TxIDHash() (chainhash.Hash, error) {
+	bb, err := hex.DecodeString(r.TxID)
+	if err != nil {
+		return chainhash.Hash{}, errors.Join(err, ErrInvalidTxIDFormat)
+	}
+	if len(bb) != chainhash.HashSize {
+		return chainhash.Hash{}, ErrInvalidTxIDLength
+	}
+
+	var hash chainhash.Hash
+	copy(hash[:], bb)
+	return hash, nil
+}
+
+// NewMerkleProofProvider defines the contract for handling new Merkle proofs.
+// It allows the overlay engine to verify mined transactions and maintain
+// a chain-of-custody for transaction outputs.
+type NewMerkleProofProvider interface {
+	HandleNewMerkleProof(ctx context.Context, txid *chainhash.Hash, proof *transaction.MerklePath) error
+}
+
+// ArcIngestHandler orchestrates the processing of ARC ingest requests, including
+// validation of incoming request bodies, conversion of the data into the
+// appropriate format, and forwarding the data to the overlay engine for processing.
+type ArcIngestHandler struct {
+	provider         NewMerkleProofProvider
+	requestBodyLimit int64
+	responseTimeout  time.Duration
+}
+
+// decode reads and decodes the request body into the provided destination
+// struct. It ensures the request body size is within the allowed limit.
+func (h *ArcIngestHandler) decode(body io.Reader, dst *ArcIngestRequest) error {
+	reader := jsonutil.LimitedBodyReader{
+		Body:      body,
+		ReadLimit: jsonutil.RequestBodyLimit1GB,
+	}
+
+	bb, err := reader.Read()
+	if err != nil {
+		return fmt.Errorf("body reader failure: %w", err)
+	}
+
+	err = jsonutil.DecodeBytes(bb, dst)
+	if err != nil {
+		return fmt.Errorf("decode bytes failure: %w", err)
+	}
+	return nil
+}
+
+// buildHandleNewMerkleProofArguments decodes the request body, validates the
+// fields, and returns the Merkle proof data (TxID and MerklePath) for further
+// processing by the provider.
+func (h *ArcIngestHandler) buildHandleNewMerkleProofArguments(body io.Reader) (chainhash.Hash, *transaction.MerklePath, error) {
+	var dst ArcIngestRequest
+	err := h.decode(body, &dst)
+	if err != nil {
+		return chainhash.Hash{}, nil, err
+	}
+
+	err = dst.Validate()
+	if err != nil {
+		return chainhash.Hash{}, nil, err
+	}
+
+	txIDHash, err := dst.TxIDHash()
+	if err != nil {
+		return chainhash.Hash{}, nil, err
+	}
+
+	merklePath, err := dst.MerklePathStruct()
+	if err != nil {
+		return chainhash.Hash{}, nil, err
+	}
+	return txIDHash, merklePath, nil
+}
+
+// Handle processes an ARC ingest request, handling the validation, converting
+// the request data into the correct format, and invoking the provider to handle
+// the new Merkle proof. It also manages timeout and error responses.
+func (h *ArcIngestHandler) Handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		jsonutil.SendHTTPResponse(w, http.StatusMethodNotAllowed, NewFailureArcIngestHandlerResponse(ErrInvalidHTTPMethod.Error()))
+		return
+	}
+
+	txIDHash, merklePath, err := h.buildHandleNewMerkleProofArguments(r.Body)
+	if err != nil {
+		slog.Error(err.Error()) // TODO: replace with structured logging
+
+		switch {
+		case errors.Is(err, jsonutil.ErrBodyReaderFailure),
+			errors.Is(err, jsonutil.JSONDecoderFailure):
+			jsonutil.SendHTTPResponse(w, http.StatusInternalServerError, NewInternalFailureArcIngestHandlerResponse())
+			return
+
+		case errors.Is(err, ErrInvalidMerklePathFormat):
+			jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(ErrInvalidMerklePathFormat.Error()))
+			return
+
+		case errors.Is(err, ErrInvalidTxIDFormat):
+			jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(ErrInvalidTxIDFormat.Error()))
+			return
+
+		default:
+			jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(err.Error()))
+			return
+		}
+	}
+
+	errCh := make(chan error, 1)
+	defer close(errCh)
+	go func() { errCh <- h.provider.HandleNewMerkleProof(r.Context(), &txIDHash, merklePath) }()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			jsonutil.SendHTTPResponse(w, http.StatusOK, NewSuccessArcIngestHandlerResponse())
+			return
+		}
+
+		slog.Error(err.Error()) // TODO: replace with structured logging
+		jsonutil.SendHTTPResponse(w, http.StatusInternalServerError, NewFailureArcIngestHandlerResponse(http.StatusText(http.StatusInternalServerError)))
+
+	case <-time.After(h.responseTimeout):
+		jsonutil.SendHTTPResponse(w, http.StatusGatewayTimeout, NewFailureArcIngestHandlerResponse(http.StatusText(http.StatusGatewayTimeout)))
+	}
+}
+
+// ArcIngestHandlerOption defines a function that configures an ArcIngestHandler.
+type ArcIngestHandlerOption func(h *ArcIngestHandler)
+
+// WithArcResponseTimeout configures the timeout duration for Merkle proof processing.
+func WithArcResponseTimeout(d time.Duration) ArcIngestHandlerOption {
+	return func(h *ArcIngestHandler) {
+		h.responseTimeout = d
+	}
+}
+
+// WithArcRequestBodyLimit configures the maximum allowed size for request bodies.
+func WithArcRequestBodyLimit(limit int64) ArcIngestHandlerOption {
+	return func(h *ArcIngestHandler) {
+		h.requestBodyLimit = limit
+	}
+}
+
+// NewArcIngestHandler creates a new instance of an ArcIngestHandler, utilizing
+// the provided Merkle proof provider and any optional configurations.
+func NewArcIngestHandler(provider NewMerkleProofProvider, opts ...ArcIngestHandlerOption) (*ArcIngestHandler, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("provider is nil")
+	}
+
+	h := ArcIngestHandler{
+		provider:         provider,
+		requestBodyLimit: jsonutil.RequestBodyLimit1GB,
+		responseTimeout:  10 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(&h)
+	}
+
+	return &h, nil
+}
+
+// NewSuccessArcIngestHandlerResponse creates a success response for the ArcIngestHandler,
+// indicating that the transaction status has been successfully updated.
+func NewSuccessArcIngestHandlerResponse() ArcIngestHandlerResponse {
+	return ArcIngestHandlerResponse{Status: "success", Message: "Transaction status updated"}
+}
+
+// NewFailureArcIngestHandlerResponse creates a failure response for the ArcIngestHandler,
+// with the provided message describing the error that occurred during the process.
+func NewFailureArcIngestHandlerResponse(message string) ArcIngestHandlerResponse {
+	return ArcIngestHandlerResponse{
+		Status:  "error",
+		Message: message,
+	}
+}
+
+// NewInternalFailureArcIngestHandlerResponse creates a failure response for the ArcIngestHandler,
+// indicating an internal server error, with the default error message for HTTP 500.
+func NewInternalFailureArcIngestHandlerResponse() ArcIngestHandlerResponse {
+	return ArcIngestHandlerResponse{
+		Status:  "error",
+		Message: http.StatusText(http.StatusInternalServerError),
+	}
+}

--- a/pkg/server/internal/app/commands/arc_ingest.go
+++ b/pkg/server/internal/app/commands/arc_ingest.go
@@ -36,17 +36,17 @@ var (
 // ArcIngestHandlerResponse represents the response format for the ArcIngestHandler,
 // containing the status of the operation and a message providing additional context.
 type ArcIngestHandlerResponse struct {
-	Status  string `json:"status"`  // The status of the request (e.g., "success", "error")
-	Message string `json:"message"` // A message providing additional information about the result
+	Status  string `json:"status"`
+	Message string `json:"message"`
 }
 
 // ArcIngestRequest defines the expected structure for the ARC ingest request body,
 // containing the transaction ID, Merkle path, and block height. This structure
 // is used to validate and process incoming ARC ingest requests.
 type ArcIngestRequest struct {
-	TxID        string `json:"txid"`        // Transaction ID in hexadecimal format
-	MerklePath  string `json:"merklePath"`  // Merkle path as a hex string
-	BlockHeight uint32 `json:"blockHeight"` // Block height associated with the Merkle path
+	TxID        string `json:"txid"`
+	MerklePath  string `json:"merklePath"`
+	BlockHeight uint32 `json:"blockHeight"`
 }
 
 // IsMerklePathEmpty checks if the MerklePath field is empty, indicating missing data.

--- a/pkg/server/internal/app/commands/arc_ingest.go
+++ b/pkg/server/internal/app/commands/arc_ingest.go
@@ -16,276 +16,450 @@ import (
 )
 
 var (
+
 	// ErrInvalidTxIDFormat is returned when the transaction ID is not in a valid format (e.g., not hexadecimal).
+
 	ErrInvalidTxIDFormat = errors.New("invalid transaction ID format")
 
 	// ErrInvalidTxIDLength is returned when the transaction ID does not match the expected length (typically 64 characters for a SHA-256 hash).
+
 	ErrInvalidTxIDLength = errors.New("invalid transaction ID length")
 
 	// ErrInvalidMerklePathFormat is returned when the Merkle path is malformed or does not conform to the expected structure.
+
 	ErrInvalidMerklePathFormat = errors.New("invalid Merkle path format")
 
 	// ErrMissingRequiredRequestFieldsDefinition is returned when the request body is missing
+
 	// required fields, such as the transaction ID and Merkle path.
+
 	ErrMissingRequiredRequestFieldsDefinition = errors.New("missing required fields: txid, merkle path")
 
 	// ErrMissingRequiredTxIDFieldDefinition is returned when the request body is missing
+
 	// the required transaction ID field.
+
 	ErrMissingRequiredTxIDFieldDefinition = errors.New("missing required field: txid")
 
 	// ErrMissingRequiredMerklePathFieldDefinition is returned when the request body is missing
+
 	// the required Merkle path field.
+
 	ErrMissingRequiredMerklePathFieldDefinition = errors.New("missing required field: merkle path")
 )
 
 // ArcIngestHandlerResponse represents the response format for the ArcIngestHandler,
+
 // containing the status of the operation and a message providing additional context.
+
 type ArcIngestHandlerResponse struct {
-	Status  string `json:"status"`  // The status of the request (e.g., "success", "error")
+	Status string `json:"status"` // The status of the request (e.g., "success", "error")
+
 	Message string `json:"message"` // A message providing additional information about the result
+
 }
 
 // ArcIngestRequest defines the expected structure for the ARC ingest request body,
+
 // containing the transaction ID, Merkle path, and block height. This structure
+
 // is used to validate and process incoming ARC ingest requests.
+
 type ArcIngestRequest struct {
-	TxID        string `json:"txid"`        // Transaction ID in hexadecimal format
-	MerklePath  string `json:"merklePath"`  // Merkle path as a hex string
+	TxID string `json:"txid"` // Transaction ID in hexadecimal format
+
+	MerklePath string `json:"merklePath"` // Merkle path as a hex string
+
 	BlockHeight uint32 `json:"blockHeight"` // Block height associated with the Merkle path
+
 }
 
 // IsMerklePathEmpty checks if the MerklePath field is empty, indicating missing data.
+
 func (r *ArcIngestRequest) IsMerklePathEmpty() bool {
+
 	return r.MerklePath == ""
+
 }
 
 // IsTxIDEmpty checks if the TxID field is empty, indicating missing data.
+
 func (r *ArcIngestRequest) IsTxIDEmpty() bool {
+
 	return r.TxID == ""
+
 }
 
 // IsEmpty checks if all fields in the ArcIngestRequest are zero or empty values,
+
 // signifying an invalid or incomplete request.
+
 func (r *ArcIngestRequest) IsEmpty() bool {
+
 	return r.TxID == "" && r.MerklePath == "" && r.BlockHeight == 0
+
 }
 
 // Validate checks if all required fields are present and valid. It returns an
+
 // error if any of the required fields are missing or improperly formatted.
+
 func (r *ArcIngestRequest) Validate() error {
+
 	if r.IsEmpty() {
+
 		return ErrMissingRequiredRequestFieldsDefinition
+
 	}
+
 	if r.IsTxIDEmpty() {
+
 		return ErrMissingRequiredTxIDFieldDefinition
+
 	}
+
 	if r.IsMerklePathEmpty() {
+
 		return ErrMissingRequiredMerklePathFieldDefinition
+
 	}
 
 	return nil
+
 }
 
 // MerklePathStruct parses the MerklePath hex string and returns the Merkle path
+
 // structure. It also sets the associated block height on the resulting structure.
+
 func (r *ArcIngestRequest) MerklePathStruct() (*transaction.MerklePath, error) {
+
 	path, err := transaction.NewMerklePathFromHex(r.MerklePath)
+
 	if err != nil {
+
 		return nil, errors.Join(err, ErrInvalidMerklePathFormat)
+
 	}
 
 	path.BlockHeight = r.BlockHeight
+
 	return path, nil
+
 }
 
 // TxIDHash converts the transaction ID (TxID) from a hex string to a chainhash.Hash
+
 // representation. It returns an error if the string is improperly formatted or has
+
 // an invalid length.
+
 func (r *ArcIngestRequest) TxIDHash() (chainhash.Hash, error) {
+
 	bb, err := hex.DecodeString(r.TxID)
+
 	if err != nil {
+
 		return chainhash.Hash{}, errors.Join(err, ErrInvalidTxIDFormat)
+
 	}
+
 	if len(bb) != chainhash.HashSize {
+
 		return chainhash.Hash{}, ErrInvalidTxIDLength
+
 	}
 
 	var hash chainhash.Hash
+
 	copy(hash[:], bb)
+
 	return hash, nil
+
 }
 
 // NewMerkleProofProvider defines the contract for handling new Merkle proofs.
+
 // It allows the overlay engine to verify mined transactions and maintain
+
 // a chain-of-custody for transaction outputs.
+
 type NewMerkleProofProvider interface {
 	HandleNewMerkleProof(ctx context.Context, txid *chainhash.Hash, proof *transaction.MerklePath) error
 }
 
 // ArcIngestHandler orchestrates the processing of ARC ingest requests, including
+
 // validation of incoming request bodies, conversion of the data into the
+
 // appropriate format, and forwarding the data to the overlay engine for processing.
+
 type ArcIngestHandler struct {
-	provider         NewMerkleProofProvider
+	provider NewMerkleProofProvider
+
 	requestBodyLimit int64
-	responseTimeout  time.Duration
+
+	responseTimeout time.Duration
 }
 
 // decode reads and decodes the request body into the provided destination
+
 // struct. It ensures the request body size is within the allowed limit.
+
 func (h *ArcIngestHandler) decode(body io.Reader, dst *ArcIngestRequest) error {
+
 	reader := jsonutil.LimitedBodyReader{
-		Body:      body,
+
+		Body: body,
+
 		ReadLimit: jsonutil.RequestBodyLimit1GB,
 	}
 
 	bb, err := reader.Read()
+
 	if err != nil {
+
 		return fmt.Errorf("body reader failure: %w", err)
+
 	}
 
 	err = jsonutil.DecodeBytes(bb, dst)
+
 	if err != nil {
+
 		return fmt.Errorf("decode bytes failure: %w", err)
+
 	}
+
 	return nil
+
 }
 
 // buildHandleNewMerkleProofArguments decodes the request body, validates the
+
 // fields, and returns the Merkle proof data (TxID and MerklePath) for further
+
 // processing by the provider.
+
 func (h *ArcIngestHandler) buildHandleNewMerkleProofArguments(body io.Reader) (chainhash.Hash, *transaction.MerklePath, error) {
+
 	var dst ArcIngestRequest
+
 	err := h.decode(body, &dst)
+
 	if err != nil {
+
 		return chainhash.Hash{}, nil, err
+
 	}
 
 	err = dst.Validate()
+
 	if err != nil {
+
 		return chainhash.Hash{}, nil, err
+
 	}
 
 	txIDHash, err := dst.TxIDHash()
+
 	if err != nil {
+
 		return chainhash.Hash{}, nil, err
+
 	}
 
 	merklePath, err := dst.MerklePathStruct()
+
 	if err != nil {
+
 		return chainhash.Hash{}, nil, err
+
 	}
+
 	return txIDHash, merklePath, nil
+
 }
 
 // Handle processes an ARC ingest request, handling the validation, converting
+
 // the request data into the correct format, and invoking the provider to handle
+
 // the new Merkle proof. It also manages timeout and error responses.
+
 func (h *ArcIngestHandler) Handle(w http.ResponseWriter, r *http.Request) {
+
 	if r.Method != http.MethodPost {
+
 		jsonutil.SendHTTPResponse(w, http.StatusMethodNotAllowed, NewFailureArcIngestHandlerResponse(ErrInvalidHTTPMethod.Error()))
+
 		return
+
 	}
 
 	txIDHash, merklePath, err := h.buildHandleNewMerkleProofArguments(r.Body)
+
 	if err != nil {
+
 		slog.Error(err.Error()) // TODO: replace with structured logging
 
 		switch {
+
 		case errors.Is(err, jsonutil.ErrBodyReaderFailure),
+
 			errors.Is(err, jsonutil.JSONDecoderFailure):
+
 			jsonutil.SendHTTPResponse(w, http.StatusInternalServerError, NewInternalFailureArcIngestHandlerResponse())
+
 			return
 
 		case errors.Is(err, ErrInvalidMerklePathFormat):
+
 			jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(ErrInvalidMerklePathFormat.Error()))
+
 			return
 
 		case errors.Is(err, ErrInvalidTxIDFormat):
+
 			jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(ErrInvalidTxIDFormat.Error()))
+
 			return
 
 		default:
+
 			jsonutil.SendHTTPResponse(w, http.StatusBadRequest, NewFailureArcIngestHandlerResponse(err.Error()))
+
 			return
+
 		}
+
 	}
 
 	errCh := make(chan error, 1)
+
 	defer close(errCh)
+
 	go func() { errCh <- h.provider.HandleNewMerkleProof(r.Context(), &txIDHash, merklePath) }()
 
 	select {
+
 	case err := <-errCh:
+
 		if err == nil {
+
 			jsonutil.SendHTTPResponse(w, http.StatusOK, NewSuccessArcIngestHandlerResponse())
+
 			return
+
 		}
 
 		slog.Error(err.Error()) // TODO: replace with structured logging
+
 		jsonutil.SendHTTPResponse(w, http.StatusInternalServerError, NewFailureArcIngestHandlerResponse(http.StatusText(http.StatusInternalServerError)))
 
 	case <-time.After(h.responseTimeout):
+
 		jsonutil.SendHTTPResponse(w, http.StatusGatewayTimeout, NewFailureArcIngestHandlerResponse(http.StatusText(http.StatusGatewayTimeout)))
+
 	}
+
 }
 
 // ArcIngestHandlerOption defines a function that configures an ArcIngestHandler.
+
 type ArcIngestHandlerOption func(h *ArcIngestHandler)
 
 // WithArcResponseTimeout configures the timeout duration for Merkle proof processing.
+
 func WithArcResponseTimeout(d time.Duration) ArcIngestHandlerOption {
+
 	return func(h *ArcIngestHandler) {
+
 		h.responseTimeout = d
+
 	}
+
 }
 
 // WithArcRequestBodyLimit configures the maximum allowed size for request bodies.
+
 func WithArcRequestBodyLimit(limit int64) ArcIngestHandlerOption {
+
 	return func(h *ArcIngestHandler) {
+
 		h.requestBodyLimit = limit
+
 	}
+
 }
 
 // NewArcIngestHandler creates a new instance of an ArcIngestHandler, utilizing
+
 // the provided Merkle proof provider and any optional configurations.
+
 func NewArcIngestHandler(provider NewMerkleProofProvider, opts ...ArcIngestHandlerOption) (*ArcIngestHandler, error) {
+
 	if provider == nil {
+
 		return nil, fmt.Errorf("provider is nil")
+
 	}
 
 	h := ArcIngestHandler{
-		provider:         provider,
+
+		provider: provider,
+
 		requestBodyLimit: jsonutil.RequestBodyLimit1GB,
-		responseTimeout:  10 * time.Second,
+
+		responseTimeout: 10 * time.Second,
 	}
+
 	for _, opt := range opts {
+
 		opt(&h)
+
 	}
 
 	return &h, nil
+
 }
 
 // NewSuccessArcIngestHandlerResponse creates a success response for the ArcIngestHandler,
+
 // indicating that the transaction status has been successfully updated.
+
 func NewSuccessArcIngestHandlerResponse() ArcIngestHandlerResponse {
+
 	return ArcIngestHandlerResponse{Status: "success", Message: "Transaction status updated"}
+
 }
 
 // NewFailureArcIngestHandlerResponse creates a failure response for the ArcIngestHandler,
+
 // with the provided message describing the error that occurred during the process.
+
 func NewFailureArcIngestHandlerResponse(message string) ArcIngestHandlerResponse {
+
 	return ArcIngestHandlerResponse{
-		Status:  "error",
+
+		Status: "error",
+
 		Message: message,
 	}
+
 }
 
 // NewInternalFailureArcIngestHandlerResponse creates a failure response for the ArcIngestHandler,
+
 // indicating an internal server error, with the default error message for HTTP 500.
+
 func NewInternalFailureArcIngestHandlerResponse() ArcIngestHandlerResponse {
+
 	return ArcIngestHandlerResponse{
-		Status:  "error",
+
+		Status: "error",
+
 		Message: http.StatusText(http.StatusInternalServerError),
 	}
+
 }

--- a/pkg/server/internal/app/commands/arc_ingest.go
+++ b/pkg/server/internal/app/commands/arc_ingest.go
@@ -36,7 +36,7 @@ var (
 // ArcIngestHandlerResponse represents the response format for the ArcIngestHandler,
 // containing the status of the operation and a message providing additional context.
 type ArcIngestHandlerResponse struct {
-	Status string `json:"status"` // The status of the request (e.g., "success", "error")
+	Status  string `json:"status"`  // The status of the request (e.g., "success", "error")
 	Message string `json:"message"` // A message providing additional information about the result
 }
 
@@ -44,8 +44,8 @@ type ArcIngestHandlerResponse struct {
 // containing the transaction ID, Merkle path, and block height. This structure
 // is used to validate and process incoming ARC ingest requests.
 type ArcIngestRequest struct {
-	TxID string `json:"txid"` // Transaction ID in hexadecimal format
-	MerklePath string `json:"merklePath"` // Merkle path as a hex string
+	TxID        string `json:"txid"`        // Transaction ID in hexadecimal format
+	MerklePath  string `json:"merklePath"`  // Merkle path as a hex string
 	BlockHeight uint32 `json:"blockHeight"` // Block height associated with the Merkle path
 }
 
@@ -118,16 +118,16 @@ type NewMerkleProofProvider interface {
 // validation of incoming request bodies, conversion of the data into the
 // appropriate format, and forwarding the data to the overlay engine for processing.
 type ArcIngestHandler struct {
-	provider NewMerkleProofProvider
+	provider         NewMerkleProofProvider
 	requestBodyLimit int64
-	responseTimeout time.Duration
+	responseTimeout  time.Duration
 }
 
 // decode reads and decodes the request body into the provided destination
 // struct. It ensures the request body size is within the allowed limit.
 func (h *ArcIngestHandler) decode(body io.Reader, dst *ArcIngestRequest) error {
 	reader := jsonutil.LimitedBodyReader{
-		Body: body,
+		Body:      body,
 		ReadLimit: jsonutil.RequestBodyLimit1GB,
 	}
 	bb, err := reader.Read()
@@ -234,9 +234,9 @@ func NewArcIngestHandler(provider NewMerkleProofProvider, opts ...ArcIngestHandl
 		return nil, fmt.Errorf("provider is nil")
 	}
 	h := ArcIngestHandler{
-		provider: provider,
+		provider:         provider,
 		requestBodyLimit: jsonutil.RequestBodyLimit1GB,
-		responseTimeout: 10 * time.Second,
+		responseTimeout:  10 * time.Second,
 	}
 	for _, opt := range opts {
 		opt(&h)
@@ -254,7 +254,7 @@ func NewSuccessArcIngestHandlerResponse() ArcIngestHandlerResponse {
 // with the provided message describing the error that occurred during the process.
 func NewFailureArcIngestHandlerResponse(message string) ArcIngestHandlerResponse {
 	return ArcIngestHandlerResponse{
-		Status: "error",
+		Status:  "error",
 		Message: message,
 	}
 }
@@ -263,7 +263,7 @@ func NewFailureArcIngestHandlerResponse(message string) ArcIngestHandlerResponse
 // indicating an internal server error, with the default error message for HTTP 500.
 func NewInternalFailureArcIngestHandlerResponse() ArcIngestHandlerResponse {
 	return ArcIngestHandlerResponse{
-		Status: "error",
+		Status:  "error",
 		Message: http.StatusText(http.StatusInternalServerError),
 	}
 }

--- a/pkg/server/internal/app/commands/arc_ingest_test.go
+++ b/pkg/server/internal/app/commands/arc_ingest_test.go
@@ -51,11 +51,11 @@ func Test_ArcIngestHandler_ShouldRespondsWith200AndCallsProvider(t *testing.T) {
 
 func Test_ArcIngestHandler_ValidationTests(t *testing.T) {
 	tests := map[string]struct {
-		method         string
-		payload        commands.ArcIngestRequest
-		setupRequest   func(*http.Request)
-		expectedResponse commands.ArcIngestHandlerResponse
-		expectedHTTPStatus  int
+		method             string
+		payload            commands.ArcIngestRequest
+		setupRequest       func(*http.Request)
+		expectedResponse   commands.ArcIngestHandlerResponse
+		expectedHTTPStatus int
 	}{
 		"should fail with 405 when HTTP method is GET": {
 			method: http.MethodGet,
@@ -64,8 +64,8 @@ func Test_ArcIngestHandler_ValidationTests(t *testing.T) {
 				MerklePath:  testutil.NewValidTestMerklePath(t),
 				BlockHeight: 848372,
 			},
-			expectedResponse: commands.NewFailureArcIngestHandlerResponse(commands.ErrInvalidHTTPMethod.Error()),
-			expectedHTTPStatus:  http.StatusMethodNotAllowed,
+			expectedResponse:   commands.NewFailureArcIngestHandlerResponse(commands.ErrInvalidHTTPMethod.Error()),
+			expectedHTTPStatus: http.StatusMethodNotAllowed,
 		},
 		"should fail with 400 when all required fields are missing": {
 			method: http.MethodPost,
@@ -74,8 +74,8 @@ func Test_ArcIngestHandler_ValidationTests(t *testing.T) {
 				MerklePath:  "",
 				BlockHeight: 0,
 			},
-			expectedResponse: commands.NewFailureArcIngestHandlerResponse(commands.ErrMissingRequiredRequestFieldsDefinition.Error()),
-			expectedHTTPStatus:  http.StatusBadRequest,
+			expectedResponse:   commands.NewFailureArcIngestHandlerResponse(commands.ErrMissingRequiredRequestFieldsDefinition.Error()),
+			expectedHTTPStatus: http.StatusBadRequest,
 		},
 		"should fail with 400 when TxID field is missing": {
 			method: http.MethodPost,
@@ -84,8 +84,8 @@ func Test_ArcIngestHandler_ValidationTests(t *testing.T) {
 				MerklePath:  testutil.NewValidTestMerklePath(t),
 				BlockHeight: 848372,
 			},
-			expectedResponse: commands.NewFailureArcIngestHandlerResponse(commands.ErrMissingRequiredTxIDFieldDefinition.Error()),
-			expectedHTTPStatus:  http.StatusBadRequest,
+			expectedResponse:   commands.NewFailureArcIngestHandlerResponse(commands.ErrMissingRequiredTxIDFieldDefinition.Error()),
+			expectedHTTPStatus: http.StatusBadRequest,
 		},
 		"should fail with 400 when MerklePath field is missing": {
 			method: http.MethodPost,
@@ -94,8 +94,8 @@ func Test_ArcIngestHandler_ValidationTests(t *testing.T) {
 				MerklePath:  "",
 				BlockHeight: 848372,
 			},
-			expectedResponse: commands.NewFailureArcIngestHandlerResponse(commands.ErrMissingRequiredMerklePathFieldDefinition.Error()),
-			expectedHTTPStatus:  http.StatusBadRequest,
+			expectedResponse:   commands.NewFailureArcIngestHandlerResponse(commands.ErrMissingRequiredMerklePathFieldDefinition.Error()),
+			expectedHTTPStatus: http.StatusBadRequest,
 		},
 		"should fail with 400 when TxID format is invalid": {
 			method: http.MethodPost,
@@ -104,8 +104,8 @@ func Test_ArcIngestHandler_ValidationTests(t *testing.T) {
 				MerklePath:  testutil.NewValidTestMerklePath(t),
 				BlockHeight: 848372,
 			},
-			expectedResponse: commands.NewFailureArcIngestHandlerResponse(commands.ErrInvalidTxIDFormat.Error()),
-			expectedHTTPStatus:  http.StatusBadRequest,
+			expectedResponse:   commands.NewFailureArcIngestHandlerResponse(commands.ErrInvalidTxIDFormat.Error()),
+			expectedHTTPStatus: http.StatusBadRequest,
 		},
 		"should fail with 400 when TxID length is invalid": {
 			method: http.MethodPost,
@@ -114,8 +114,8 @@ func Test_ArcIngestHandler_ValidationTests(t *testing.T) {
 				MerklePath:  testutil.NewValidTestMerklePath(t),
 				BlockHeight: 848372,
 			},
-			expectedResponse: commands.NewFailureArcIngestHandlerResponse(commands.ErrInvalidTxIDLength.Error()),
-			expectedHTTPStatus:  http.StatusBadRequest,
+			expectedResponse:   commands.NewFailureArcIngestHandlerResponse(commands.ErrInvalidTxIDLength.Error()),
+			expectedHTTPStatus: http.StatusBadRequest,
 		},
 		"should fail with 400 when MerklePath format is invalid": {
 			method: http.MethodPost,
@@ -124,8 +124,8 @@ func Test_ArcIngestHandler_ValidationTests(t *testing.T) {
 				MerklePath:  "invalid-merkle-path",
 				BlockHeight: 848372,
 			},
-			expectedResponse: commands.NewFailureArcIngestHandlerResponse(commands.ErrInvalidMerklePathFormat.Error()),
-			expectedHTTPStatus:  http.StatusBadRequest,
+			expectedResponse:   commands.NewFailureArcIngestHandlerResponse(commands.ErrInvalidMerklePathFormat.Error()),
+			expectedHTTPStatus: http.StatusBadRequest,
 		},
 	}
 

--- a/pkg/server/internal/app/commands/arc_ingest_test.go
+++ b/pkg/server/internal/app/commands/arc_ingest_test.go
@@ -1,0 +1,193 @@
+package commands_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/4chain-ag/go-overlay-services/pkg/server/internal/app/commands"
+	"github.com/4chain-ag/go-overlay-services/pkg/server/internal/app/commands/testutil"
+	"github.com/4chain-ag/go-overlay-services/pkg/server/internal/app/jsonutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_ArcIngestHandler_ShouldRespondsWith200AndCallsProvider tests the successful handling of a valid request
+func Test_ArcIngestHandler_ShouldRespondsWith200AndCallsProvider(t *testing.T) {
+	// given:
+	payload := commands.ArcIngestRequest{
+		TxID:        testutil.ValidTxId,
+		MerklePath:  testutil.NewValidTestMerklePath(t),
+		BlockHeight: 848372,
+	}
+
+	mock := testutil.NewMerkleProofProviderMock(nil, payload.BlockHeight)
+	handler, err := commands.NewArcIngestHandler(mock)
+
+	require.NoError(t, err)
+	ts := httptest.NewServer(http.HandlerFunc(handler.Handle))
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL, testutil.RequestBody(t, payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	// when:
+	res, err := ts.Client().Do(req)
+
+	// then:
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	require.NotNil(t, res)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var actualResponse commands.ArcIngestHandlerResponse
+	require.NoError(t, jsonutil.DecodeResponseBody(res, &actualResponse))
+
+	expectedResponse := commands.NewSuccessArcIngestHandlerResponse()
+	require.Equal(t, expectedResponse, actualResponse)
+
+	mock.AssertCalled(t)
+}
+
+// Test_ArcIngestHandler_ValidationTests tests error handling for various invalid inputs
+func Test_ArcIngestHandler_ValidationTests(t *testing.T) {
+	tests := map[string]struct {
+		method           string
+		payload          commands.ArcIngestRequest
+		setupRequest     func(*http.Request)
+		expectedStatus   int
+		expectedError    error
+	}{
+		"should fail with 405 when HTTP method is GET": {
+			method: http.MethodGet,
+			payload: commands.ArcIngestRequest{
+				TxID:        testutil.ValidTxId,
+				MerklePath:  testutil.NewValidTestMerklePath(t),
+				BlockHeight: 848372,
+			},
+			expectedStatus: http.StatusMethodNotAllowed,
+			expectedError:  commands.ErrInvalidHTTPMethod,
+		},
+		"should fail with 405 when HTTP method is PUT": {
+			method: http.MethodPut,
+			payload: commands.ArcIngestRequest{
+				TxID:        testutil.ValidTxId,
+				MerklePath:  testutil.NewValidTestMerklePath(t),
+				BlockHeight: 848372,
+			},
+			expectedStatus: http.StatusMethodNotAllowed,
+			expectedError:  commands.ErrInvalidHTTPMethod,
+		},
+		"should fail with 400 when all required fields are missing": {
+			method: http.MethodPost,
+			payload: commands.ArcIngestRequest{
+				TxID:        "",
+				MerklePath:  "",
+				BlockHeight: 0,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  commands.ErrMissingRequiredRequestFieldsDefinition,
+		},
+		"should fail with 400 when TxID field is missing": {
+			method: http.MethodPost,
+			payload: commands.ArcIngestRequest{
+				TxID:        "",
+				MerklePath:  testutil.NewValidTestMerklePath(t),
+				BlockHeight: 848372,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  commands.ErrMissingRequiredTxIDFieldDefinition,
+		},
+		"should fail with 400 when MerklePath field is missing": {
+			method: http.MethodPost,
+			payload: commands.ArcIngestRequest{
+				TxID:        testutil.ValidTxId,
+				MerklePath:  "",
+				BlockHeight: 848372,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  commands.ErrMissingRequiredMerklePathFieldDefinition,
+		},
+		"should fail with 400 when TxID format is invalid": {
+			method: http.MethodPost,
+			payload: commands.ArcIngestRequest{
+				TxID:        "invalid-hex-string",
+				MerklePath:  testutil.NewValidTestMerklePath(t),
+				BlockHeight: 848372,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  commands.ErrInvalidTxIDFormat,
+		},
+		"should fail with 400 when TxID length is invalid": {
+			method: http.MethodPost,
+			payload: commands.ArcIngestRequest{
+				TxID:        "1234",
+				MerklePath:  testutil.NewValidTestMerklePath(t),
+				BlockHeight: 848372,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  commands.ErrInvalidTxIDLength,
+		},
+		"should fail with 400 when MerklePath format is invalid": {
+			method: http.MethodPost,
+			payload: commands.ArcIngestRequest{
+				TxID:        testutil.ValidTxId,
+				MerklePath:  "invalid-merkle-path",
+				BlockHeight: 848372,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  commands.ErrInvalidMerklePathFormat,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			mock := testutil.NewMerkleProofProviderMock(nil, tc.payload.BlockHeight)
+			handler, err := commands.NewArcIngestHandler(mock)
+			require.NoError(t, err)
+
+			ts := httptest.NewServer(http.HandlerFunc(handler.Handle))
+			defer ts.Close()
+
+			var requestBody io.Reader
+			if tc.setupRequest == nil {
+				data, err := json.Marshal(tc.payload)
+				require.NoError(t, err)
+				requestBody = bytes.NewReader(data)
+			} else {
+				requestBody = bytes.NewReader([]byte{})
+			}
+
+			req, err := http.NewRequest(tc.method, ts.URL, requestBody)
+			require.NoError(t, err)
+			
+			if tc.method == http.MethodPost {
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			if tc.setupRequest != nil {
+				tc.setupRequest(req)
+			}
+
+			// when:
+			res, err := ts.Client().Do(req)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			// then:
+			require.Equal(t, tc.expectedStatus, res.StatusCode)
+
+			var response commands.ArcIngestHandlerResponse
+			err = jsonutil.DecodeResponseBody(res, &response)
+			require.NoError(t, err)
+			
+			require.Contains(t, response.Message, tc.expectedError.Error())
+			require.Equal(t, "error", response.Status)
+		})
+	}
+}

--- a/pkg/server/internal/app/commands/arc_ingest_test.go
+++ b/pkg/server/internal/app/commands/arc_ingest_test.go
@@ -56,11 +56,11 @@ func Test_ArcIngestHandler_ShouldRespondsWith200AndCallsProvider(t *testing.T) {
 // Test_ArcIngestHandler_ValidationTests tests error handling for various invalid inputs
 func Test_ArcIngestHandler_ValidationTests(t *testing.T) {
 	tests := map[string]struct {
-		method           string
-		payload          commands.ArcIngestRequest
-		setupRequest     func(*http.Request)
-		expectedStatus   int
-		expectedError    error
+		method         string
+		payload        commands.ArcIngestRequest
+		setupRequest   func(*http.Request)
+		expectedStatus int
+		expectedError  error
 	}{
 		"should fail with 405 when HTTP method is GET": {
 			method: http.MethodGet,
@@ -165,7 +165,7 @@ func Test_ArcIngestHandler_ValidationTests(t *testing.T) {
 
 			req, err := http.NewRequest(tc.method, ts.URL, requestBody)
 			require.NoError(t, err)
-			
+
 			if tc.method == http.MethodPost {
 				req.Header.Set("Content-Type", "application/json")
 			}
@@ -185,7 +185,7 @@ func Test_ArcIngestHandler_ValidationTests(t *testing.T) {
 			var response commands.ArcIngestHandlerResponse
 			err = jsonutil.DecodeResponseBody(res, &response)
 			require.NoError(t, err)
-			
+
 			require.Contains(t, response.Message, tc.expectedError.Error())
 			require.Equal(t, "error", response.Status)
 		})

--- a/pkg/server/internal/app/commands/testutil/merkle_proof_provider_mock.go
+++ b/pkg/server/internal/app/commands/testutil/merkle_proof_provider_mock.go
@@ -11,127 +11,74 @@ import (
 )
 
 // MerkleProofProviderMock is a test double for a Merkle proof handler.
-
 // It records the inputs it was called with and returns a preconfigured error.
-
 type MerkleProofProviderMock struct {
-
 	// Expected values
-
 	err error
-
 	expectedHeight uint32
-
 	// Call tracking
-
 	called bool
-
 	calledTxID *chainhash.Hash
-
 	calledProof *transaction.MerklePath
 }
 
 // NewMerkleProofProviderMock creates a new MerkleProofProviderMock
-
 // with the expected error and block height configured.
-
 func NewMerkleProofProviderMock(err error, expectedHeight uint32) *MerkleProofProviderMock {
-
 	return &MerkleProofProviderMock{
-
 		err: err,
-
 		expectedHeight: expectedHeight,
 	}
-
 }
 
 // HandleNewMerkleProof records the input parameters and returns the configured error.
-
 func (m *MerkleProofProviderMock) HandleNewMerkleProof(
-
 	ctx context.Context,
-
 	txID *chainhash.Hash,
-
 	merklePath *transaction.MerklePath,
-
 ) error {
-
 	m.called = true
-
 	m.calledTxID = txID
-
 	m.calledProof = merklePath
-
 	return m.err
-
 }
 
 // AssertCalled verifies that HandleNewMerkleProof was called with non-nil values,
-
 // and that the Merkle path had the expected block height.
-
 func (m *MerkleProofProviderMock) AssertCalled(t *testing.T) {
-
 	t.Helper()
-
 	require.True(t, m.called, "HandleNewMerkleProof was not called")
-
 	require.NotNil(t, m.calledTxID, "txID argument was nil")
-
 	require.NotNil(t, m.calledProof, "merklePath argument was nil")
-
 	require.Equal(t, m.expectedHeight, m.calledProof.BlockHeight, "unexpected block height")
-
 }
 
 // Error returns the expected error to be used by the mock.
-
 func (m *MerkleProofProviderMock) Error() error {
-
 	return m.err
-
 }
 
 // ExpectedBlockHeight returns the configured block height for assertion.
-
 func (m *MerkleProofProviderMock) ExpectedBlockHeight() uint32 {
-
 	return m.expectedHeight
-
 }
 
 // Test data for merkle proofs
-
 // BEEF data containing transaction with merkle path information
-
 const BEEFTransactionData = "0100beef01fef4f10c000902fd020100ab2d9b3bbfc2ecf5c834f7719bf10dcabef31cfa3b78fa714bd3a2b3958fc6b5fd0301029515629d935d81e704ca97b8dc02a698c39d78f06bbb3d8d46bcaa5178f3c827018000fc94b1da08b5d0850afcc4948a9e129a2c2c0bb629090ca84fef5d326ceadbc2014100fa78356192a22189dd3c2a03bfb2e043667a55a85386a8d0f0853bbaa54ba748012100e37888006acc37cbfc6a459117c3e957b00e8ff3a90d93bc9aaa3fc9d972453701110052564e444cbe4b1f24015d91f5cfd7eff63e5f403613a7b48e77efa32761f950010900acef65445ef232f1fcb527bab67fccc90ae9d0c610a4f752d84c5e10a3415d74010500e1fadd176551150808ae96ff2b4dff487c432788d23db25fd3fb5e8b3e16b96f0103003e530f146a992ed9378807fa43bc1e6033de0711d728ee3a0ea1507b5ffff2940100006c8eca8a9d680ab2ae4dc1f0e247f282de3f32b99175e6f9ddb4f8e76ae0bf1b010100000001792c8c563b17721744d8f101d79e873aae62816d0fd47dd9d90ada219c1b252d070000006b48304502210090368b5925795abb0415a3cd6265d7abae7d3541fb7f2fdb1fdffdd916b3fce3022068136da44df8ee367807c7c59c950ea8d428adfe142268cd6371cf4c1b4c3208412102858ea1804708d1e16e77b49ba1559b3742797f5f43efd3922fa3d21557521d7cffffffff03f401000000000000fde10121026afd108ddbc05e093207ebdf06557a3d66e15b96accbf1766c2e7d6efa3d1981ac22313852713463583334356b6a7461734467764b41455a435135564c5a72516f76786d2081d846bcae65ce281829b6d81eff3862a68b8eaf4e99ad97c0c4ad2e149631c020f936ace2d2b4034710dec819e343f69ddbb1a16d721b88413b697c2475f75f504c4e8470062e6966cb7ec80864e5e1217ecf2b3f113bb5307e1ec1d338678e54b426a11a267e990f7dcd85072c7b3870fabb54812d7f8a7aaa672ce01e4f8a2c6a1d532849877329bd23be0b3383fcb437ffd1ff05aad824343bfe5bae52d5775ed99ba9d5a72038dd50f81153e674a8b1c5d659aac361e660cc5657b291eda149de2505efb0bbac0a353331393633353238334c797f3040f01934bb25733d4700a0309194a7defd8ceea7a8a59ad279c6237e2917264a115773777c5746546288b15ec1cf6788b801dd3952fec804cadbba2ff4e05464735e2db83c3509b59119efc843716c34becd2884f011f2e7f61f382237891875115b6ea5bac1c3e9ca6c575b44547d589c38c1b5a8cadb463044022016e1fdb226b465f3151aaa1e033b122dd58f3b495d2846d532f784ec8f6fc9ae022031dc12155c02e7f588c9f6d975a79c9c26cf341c1c88578cd6a87a3c01f6a73d6d6d6d6dc8000000000000001976a914010b7bfa8ff585b6d95f8a18a998cbd87508bd4188aca9010000000000001976a914254c6f1ce67d27ae4dafb03d2ba08318df2883c588ac000000000100"
 
 // Valid txid data containing transaction with merkle path information
-
 const ValidTxId = "27c8f37851aabc468d3dbb6bf0789dc398a602dcb897ca04e7815d939d621595"
 
 // NewValidTestMerklePath returns a valid Merkle path hex string for use in tests.
-
 // It decodes a BEEF-encoded transaction and extracts the Merkle path.
-
 func NewValidTestMerklePath(t *testing.T) string {
-
 	t.Helper()
-
 	data, err := hex.DecodeString(BEEFTransactionData)
-
 	require.NoError(t, err, "failed to decode BEEFTransactionData")
-
 	require.NotEmpty(t, data, "decoded transaction data is empty")
-
 	tx, err := transaction.NewTransactionFromBEEF(data)
-
 	require.NoError(t, err, "failed to parse transaction from BEEF format")
-
 	require.NotNil(t, tx, "transaction is nil")
-
 	return tx.MerklePath.Hex()
-
 }

--- a/pkg/server/internal/app/commands/testutil/merkle_proof_provider_mock.go
+++ b/pkg/server/internal/app/commands/testutil/merkle_proof_provider_mock.go
@@ -13,10 +13,8 @@ import (
 // MerkleProofProviderMock is a test double for a Merkle proof handler.
 // It records the inputs it was called with and returns a preconfigured error.
 type MerkleProofProviderMock struct {
-	// Expected values
 	err            error
 	expectedHeight uint32
-	// Call tracking
 	called      bool
 	calledTxID  *chainhash.Hash
 	calledProof *transaction.MerklePath

--- a/pkg/server/internal/app/commands/testutil/merkle_proof_provider_mock.go
+++ b/pkg/server/internal/app/commands/testutil/merkle_proof_provider_mock.go
@@ -14,11 +14,11 @@ import (
 // It records the inputs it was called with and returns a preconfigured error.
 type MerkleProofProviderMock struct {
 	// Expected values
-	err error
+	err            error
 	expectedHeight uint32
 	// Call tracking
-	called bool
-	calledTxID *chainhash.Hash
+	called      bool
+	calledTxID  *chainhash.Hash
 	calledProof *transaction.MerklePath
 }
 
@@ -26,7 +26,7 @@ type MerkleProofProviderMock struct {
 // with the expected error and block height configured.
 func NewMerkleProofProviderMock(err error, expectedHeight uint32) *MerkleProofProviderMock {
 	return &MerkleProofProviderMock{
-		err: err,
+		err:            err,
 		expectedHeight: expectedHeight,
 	}
 }

--- a/pkg/server/internal/app/commands/testutil/merkle_proof_provider_mock.go
+++ b/pkg/server/internal/app/commands/testutil/merkle_proof_provider_mock.go
@@ -15,9 +15,9 @@ import (
 type MerkleProofProviderMock struct {
 	err            error
 	expectedHeight uint32
-	called      bool
-	calledTxID  *chainhash.Hash
-	calledProof *transaction.MerklePath
+	called         bool
+	calledTxID     *chainhash.Hash
+	calledProof    *transaction.MerklePath
 }
 
 // NewMerkleProofProviderMock creates a new MerkleProofProviderMock

--- a/pkg/server/internal/app/commands/testutil/merkle_proof_provider_mock.go
+++ b/pkg/server/internal/app/commands/testutil/merkle_proof_provider_mock.go
@@ -11,79 +11,127 @@ import (
 )
 
 // MerkleProofProviderMock is a test double for a Merkle proof handler.
+
 // It records the inputs it was called with and returns a preconfigured error.
+
 type MerkleProofProviderMock struct {
+
 	// Expected values
-	err            error
+
+	err error
+
 	expectedHeight uint32
 
 	// Call tracking
-	called      bool
-	calledTxID  *chainhash.Hash
+
+	called bool
+
+	calledTxID *chainhash.Hash
+
 	calledProof *transaction.MerklePath
 }
 
 // NewMerkleProofProviderMock creates a new MerkleProofProviderMock
+
 // with the expected error and block height configured.
+
 func NewMerkleProofProviderMock(err error, expectedHeight uint32) *MerkleProofProviderMock {
+
 	return &MerkleProofProviderMock{
-		err:            err,
+
+		err: err,
+
 		expectedHeight: expectedHeight,
 	}
+
 }
 
 // HandleNewMerkleProof records the input parameters and returns the configured error.
+
 func (m *MerkleProofProviderMock) HandleNewMerkleProof(
+
 	ctx context.Context,
+
 	txID *chainhash.Hash,
+
 	merklePath *transaction.MerklePath,
+
 ) error {
+
 	m.called = true
+
 	m.calledTxID = txID
+
 	m.calledProof = merklePath
+
 	return m.err
+
 }
 
 // AssertCalled verifies that HandleNewMerkleProof was called with non-nil values,
+
 // and that the Merkle path had the expected block height.
+
 func (m *MerkleProofProviderMock) AssertCalled(t *testing.T) {
+
 	t.Helper()
 
 	require.True(t, m.called, "HandleNewMerkleProof was not called")
+
 	require.NotNil(t, m.calledTxID, "txID argument was nil")
+
 	require.NotNil(t, m.calledProof, "merklePath argument was nil")
+
 	require.Equal(t, m.expectedHeight, m.calledProof.BlockHeight, "unexpected block height")
+
 }
 
 // Error returns the expected error to be used by the mock.
+
 func (m *MerkleProofProviderMock) Error() error {
+
 	return m.err
+
 }
 
 // ExpectedBlockHeight returns the configured block height for assertion.
+
 func (m *MerkleProofProviderMock) ExpectedBlockHeight() uint32 {
+
 	return m.expectedHeight
+
 }
 
 // Test data for merkle proofs
+
 // BEEF data containing transaction with merkle path information
+
 const BEEFTransactionData = "0100beef01fef4f10c000902fd020100ab2d9b3bbfc2ecf5c834f7719bf10dcabef31cfa3b78fa714bd3a2b3958fc6b5fd0301029515629d935d81e704ca97b8dc02a698c39d78f06bbb3d8d46bcaa5178f3c827018000fc94b1da08b5d0850afcc4948a9e129a2c2c0bb629090ca84fef5d326ceadbc2014100fa78356192a22189dd3c2a03bfb2e043667a55a85386a8d0f0853bbaa54ba748012100e37888006acc37cbfc6a459117c3e957b00e8ff3a90d93bc9aaa3fc9d972453701110052564e444cbe4b1f24015d91f5cfd7eff63e5f403613a7b48e77efa32761f950010900acef65445ef232f1fcb527bab67fccc90ae9d0c610a4f752d84c5e10a3415d74010500e1fadd176551150808ae96ff2b4dff487c432788d23db25fd3fb5e8b3e16b96f0103003e530f146a992ed9378807fa43bc1e6033de0711d728ee3a0ea1507b5ffff2940100006c8eca8a9d680ab2ae4dc1f0e247f282de3f32b99175e6f9ddb4f8e76ae0bf1b010100000001792c8c563b17721744d8f101d79e873aae62816d0fd47dd9d90ada219c1b252d070000006b48304502210090368b5925795abb0415a3cd6265d7abae7d3541fb7f2fdb1fdffdd916b3fce3022068136da44df8ee367807c7c59c950ea8d428adfe142268cd6371cf4c1b4c3208412102858ea1804708d1e16e77b49ba1559b3742797f5f43efd3922fa3d21557521d7cffffffff03f401000000000000fde10121026afd108ddbc05e093207ebdf06557a3d66e15b96accbf1766c2e7d6efa3d1981ac22313852713463583334356b6a7461734467764b41455a435135564c5a72516f76786d2081d846bcae65ce281829b6d81eff3862a68b8eaf4e99ad97c0c4ad2e149631c020f936ace2d2b4034710dec819e343f69ddbb1a16d721b88413b697c2475f75f504c4e8470062e6966cb7ec80864e5e1217ecf2b3f113bb5307e1ec1d338678e54b426a11a267e990f7dcd85072c7b3870fabb54812d7f8a7aaa672ce01e4f8a2c6a1d532849877329bd23be0b3383fcb437ffd1ff05aad824343bfe5bae52d5775ed99ba9d5a72038dd50f81153e674a8b1c5d659aac361e660cc5657b291eda149de2505efb0bbac0a353331393633353238334c797f3040f01934bb25733d4700a0309194a7defd8ceea7a8a59ad279c6237e2917264a115773777c5746546288b15ec1cf6788b801dd3952fec804cadbba2ff4e05464735e2db83c3509b59119efc843716c34becd2884f011f2e7f61f382237891875115b6ea5bac1c3e9ca6c575b44547d589c38c1b5a8cadb463044022016e1fdb226b465f3151aaa1e033b122dd58f3b495d2846d532f784ec8f6fc9ae022031dc12155c02e7f588c9f6d975a79c9c26cf341c1c88578cd6a87a3c01f6a73d6d6d6d6dc8000000000000001976a914010b7bfa8ff585b6d95f8a18a998cbd87508bd4188aca9010000000000001976a914254c6f1ce67d27ae4dafb03d2ba08318df2883c588ac000000000100"
 
 // Valid txid data containing transaction with merkle path information
+
 const ValidTxId = "27c8f37851aabc468d3dbb6bf0789dc398a602dcb897ca04e7815d939d621595"
 
 // NewValidTestMerklePath returns a valid Merkle path hex string for use in tests.
+
 // It decodes a BEEF-encoded transaction and extracts the Merkle path.
+
 func NewValidTestMerklePath(t *testing.T) string {
+
 	t.Helper()
 
 	data, err := hex.DecodeString(BEEFTransactionData)
+
 	require.NoError(t, err, "failed to decode BEEFTransactionData")
+
 	require.NotEmpty(t, data, "decoded transaction data is empty")
 
 	tx, err := transaction.NewTransactionFromBEEF(data)
+
 	require.NoError(t, err, "failed to parse transaction from BEEF format")
+
 	require.NotNil(t, tx, "transaction is nil")
 
 	return tx.MerklePath.Hex()
+
 }

--- a/pkg/server/internal/app/commands/testutil/merkle_proof_provider_mock.go
+++ b/pkg/server/internal/app/commands/testutil/merkle_proof_provider_mock.go
@@ -1,0 +1,89 @@
+package testutil
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/bsv-blockchain/go-sdk/chainhash"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/stretchr/testify/require"
+)
+
+// MerkleProofProviderMock is a test double for a Merkle proof handler.
+// It records the inputs it was called with and returns a preconfigured error.
+type MerkleProofProviderMock struct {
+	// Expected values
+	err            error
+	expectedHeight uint32
+
+	// Call tracking
+	called      bool
+	calledTxID  *chainhash.Hash
+	calledProof *transaction.MerklePath
+}
+
+// NewMerkleProofProviderMock creates a new MerkleProofProviderMock
+// with the expected error and block height configured.
+func NewMerkleProofProviderMock(err error, expectedHeight uint32) *MerkleProofProviderMock {
+	return &MerkleProofProviderMock{
+		err:            err,
+		expectedHeight: expectedHeight,
+	}
+}
+
+// HandleNewMerkleProof records the input parameters and returns the configured error.
+func (m *MerkleProofProviderMock) HandleNewMerkleProof(
+	ctx context.Context,
+	txID *chainhash.Hash,
+	merklePath *transaction.MerklePath,
+) error {
+	m.called = true
+	m.calledTxID = txID
+	m.calledProof = merklePath
+	return m.err
+}
+
+// AssertCalled verifies that HandleNewMerkleProof was called with non-nil values,
+// and that the Merkle path had the expected block height.
+func (m *MerkleProofProviderMock) AssertCalled(t *testing.T) {
+	t.Helper()
+
+	require.True(t, m.called, "HandleNewMerkleProof was not called")
+	require.NotNil(t, m.calledTxID, "txID argument was nil")
+	require.NotNil(t, m.calledProof, "merklePath argument was nil")
+	require.Equal(t, m.expectedHeight, m.calledProof.BlockHeight, "unexpected block height")
+}
+
+// Error returns the expected error to be used by the mock.
+func (m *MerkleProofProviderMock) Error() error {
+	return m.err
+}
+
+// ExpectedBlockHeight returns the configured block height for assertion.
+func (m *MerkleProofProviderMock) ExpectedBlockHeight() uint32 {
+	return m.expectedHeight
+}
+
+// Test data for merkle proofs
+// BEEF data containing transaction with merkle path information
+const BEEFTransactionData = "0100beef01fef4f10c000902fd020100ab2d9b3bbfc2ecf5c834f7719bf10dcabef31cfa3b78fa714bd3a2b3958fc6b5fd0301029515629d935d81e704ca97b8dc02a698c39d78f06bbb3d8d46bcaa5178f3c827018000fc94b1da08b5d0850afcc4948a9e129a2c2c0bb629090ca84fef5d326ceadbc2014100fa78356192a22189dd3c2a03bfb2e043667a55a85386a8d0f0853bbaa54ba748012100e37888006acc37cbfc6a459117c3e957b00e8ff3a90d93bc9aaa3fc9d972453701110052564e444cbe4b1f24015d91f5cfd7eff63e5f403613a7b48e77efa32761f950010900acef65445ef232f1fcb527bab67fccc90ae9d0c610a4f752d84c5e10a3415d74010500e1fadd176551150808ae96ff2b4dff487c432788d23db25fd3fb5e8b3e16b96f0103003e530f146a992ed9378807fa43bc1e6033de0711d728ee3a0ea1507b5ffff2940100006c8eca8a9d680ab2ae4dc1f0e247f282de3f32b99175e6f9ddb4f8e76ae0bf1b010100000001792c8c563b17721744d8f101d79e873aae62816d0fd47dd9d90ada219c1b252d070000006b48304502210090368b5925795abb0415a3cd6265d7abae7d3541fb7f2fdb1fdffdd916b3fce3022068136da44df8ee367807c7c59c950ea8d428adfe142268cd6371cf4c1b4c3208412102858ea1804708d1e16e77b49ba1559b3742797f5f43efd3922fa3d21557521d7cffffffff03f401000000000000fde10121026afd108ddbc05e093207ebdf06557a3d66e15b96accbf1766c2e7d6efa3d1981ac22313852713463583334356b6a7461734467764b41455a435135564c5a72516f76786d2081d846bcae65ce281829b6d81eff3862a68b8eaf4e99ad97c0c4ad2e149631c020f936ace2d2b4034710dec819e343f69ddbb1a16d721b88413b697c2475f75f504c4e8470062e6966cb7ec80864e5e1217ecf2b3f113bb5307e1ec1d338678e54b426a11a267e990f7dcd85072c7b3870fabb54812d7f8a7aaa672ce01e4f8a2c6a1d532849877329bd23be0b3383fcb437ffd1ff05aad824343bfe5bae52d5775ed99ba9d5a72038dd50f81153e674a8b1c5d659aac361e660cc5657b291eda149de2505efb0bbac0a353331393633353238334c797f3040f01934bb25733d4700a0309194a7defd8ceea7a8a59ad279c6237e2917264a115773777c5746546288b15ec1cf6788b801dd3952fec804cadbba2ff4e05464735e2db83c3509b59119efc843716c34becd2884f011f2e7f61f382237891875115b6ea5bac1c3e9ca6c575b44547d589c38c1b5a8cadb463044022016e1fdb226b465f3151aaa1e033b122dd58f3b495d2846d532f784ec8f6fc9ae022031dc12155c02e7f588c9f6d975a79c9c26cf341c1c88578cd6a87a3c01f6a73d6d6d6d6dc8000000000000001976a914010b7bfa8ff585b6d95f8a18a998cbd87508bd4188aca9010000000000001976a914254c6f1ce67d27ae4dafb03d2ba08318df2883c588ac000000000100"
+
+// Valid txid data containing transaction with merkle path information
+const ValidTxId = "27c8f37851aabc468d3dbb6bf0789dc398a602dcb897ca04e7815d939d621595"
+
+// NewValidTestMerklePath returns a valid Merkle path hex string for use in tests.
+// It decodes a BEEF-encoded transaction and extracts the Merkle path.
+func NewValidTestMerklePath(t *testing.T) string {
+	t.Helper()
+
+	data, err := hex.DecodeString(BEEFTransactionData)
+	require.NoError(t, err, "failed to decode BEEFTransactionData")
+	require.NotEmpty(t, data, "decoded transaction data is empty")
+
+	tx, err := transaction.NewTransactionFromBEEF(data)
+	require.NoError(t, err, "failed to parse transaction from BEEF format")
+	require.NotNil(t, tx, "transaction is nil")
+
+	return tx.MerklePath.Hex()
+}

--- a/pkg/server/internal/app/jsonutil/jsonutil.go
+++ b/pkg/server/internal/app/jsonutil/jsonutil.go
@@ -1,11 +1,11 @@
 package jsonutil
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
-	"bytes"
-	"errors"
 )
 
 // SendHTTPResponse replies to the request with the specified HTTP status code and response body content.

--- a/pkg/server/internal/app/jsonutil/jsonutil.go
+++ b/pkg/server/internal/app/jsonutil/jsonutil.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"bytes"
+	"errors"
 )
 
 // SendHTTPResponse replies to the request with the specified HTTP status code and response body content.
@@ -49,3 +51,19 @@ func DecodeRequestBody(r *http.Request, dst any) error {
 	}
 	return nil
 }
+
+// DecodeBytes deserializes JSON bytes into the provided destination object.
+// It uses a json.Decoder to parse the byte array and returns an error
+// joined with JSONDecoderFailure if the decoding process fails.
+func DecodeBytes(bb []byte, dst any) error {
+	dec := json.NewDecoder(bytes.NewBuffer(bb))
+	err := dec.Decode(dst)
+	if err != nil {
+		return errors.Join(err, JSONDecoderFailure)
+	}
+	return nil
+}
+
+// JSONDecoderFailure represents an error that occurs when the JSON decoder fails
+// to parse the input data into the expected structure.
+var JSONDecoderFailure = errors.New("failed to decode JSON payload")

--- a/pkg/server/internal/app/jsonutil/limited_body_reader.go
+++ b/pkg/server/internal/app/jsonutil/limited_body_reader.go
@@ -24,8 +24,8 @@ var (
 // It helps manage reading large request bodies by ensuring the data doesn't
 // exceed a predefined size limit.
 type LimitedBodyReader struct {
-	Body io.Reader // The reader that provides the data to be read
-	ReadLimit int64 // The maximum number of bytes that can be read
+	Body      io.Reader // The reader that provides the data to be read
+	ReadLimit int64     // The maximum number of bytes that can be read
 }
 
 // Read reads data from the LimitedBodyReader's io.Reader and returns the data as a byte slice.

--- a/pkg/server/internal/app/jsonutil/limited_body_reader.go
+++ b/pkg/server/internal/app/jsonutil/limited_body_reader.go
@@ -24,8 +24,8 @@ var (
 // It helps manage reading large request bodies by ensuring the data doesn't
 // exceed a predefined size limit.
 type LimitedBodyReader struct {
-	Body      io.Reader // The reader that provides the data to be read
-	ReadLimit int64     // The maximum number of bytes that can be read
+	Body      io.Reader
+	ReadLimit int64
 }
 
 // Read reads data from the LimitedBodyReader's io.Reader and returns the data as a byte slice.

--- a/pkg/server/internal/app/jsonutil/limited_body_reader.go
+++ b/pkg/server/internal/app/jsonutil/limited_body_reader.go
@@ -1,0 +1,70 @@
+package jsonutil
+
+import (
+	"bytes"
+	"errors"
+	"io"
+)
+
+// RequestBodyLimit1GB defines the maximum allowed size for request bodies (1GB).
+const RequestBodyLimit1GB = 1000 * 1024 * 1024
+
+var (
+	// ErrRequestBodyRead is returned when there's an error reading the request body.
+	ErrRequestBodyRead = errors.New("failed to read request body")
+
+	// ErrRequestBodyTooLarge is returned when the request body exceeds the size limit.
+	ErrRequestBodyTooLarge = errors.New("request body too large")
+
+	// ErrBodyReaderFailure is returned when the body reader fails unexpectedly,
+	// without returning ErrRequestBodyRead or ErrRequestBodyTooLarge.
+	ErrBodyReaderFailure = errors.New("unexpected failure while reading request body")
+)
+
+// LimitedBodyReader is a struct that reads and processes data from an io.Reader
+// with a specified limit on the maximum number of bytes that can be read.
+// It helps manage reading large request bodies by ensuring the data doesn't
+// exceed a predefined size limit.
+type LimitedBodyReader struct {
+	Body      io.Reader // The reader that provides the data to be read
+	ReadLimit int64     // The maximum number of bytes that can be read
+}
+
+// Read reads data from the LimitedBodyReader's io.Reader and returns the data as a byte slice.
+// It will read chunks of data from the body and accumulate them until the read limit is reached
+// or until the end of the body is encountered. If the read limit is exceeded, it returns an error.
+// If the reading or writing to the buffer fails, an error is returned.
+//
+// The function reads the data in chunks of 64KB (defined by the buffer size),
+// ensuring that no more than the allowed `ReadLimit` bytes are read.
+func (l *LimitedBodyReader) Read() ([]byte, error) {
+	reader := io.LimitReader(l.Body, l.ReadLimit+1)
+	buff := bytes.NewBuffer(nil)
+	bb := make([]byte, 64*1024)
+
+	var read int64
+
+	for {
+		n, err := reader.Read(bb)
+		if n > 0 {
+			read += int64(n)
+			if read > l.ReadLimit {
+				return nil, ErrRequestBodyTooLarge
+			}
+
+			_, err := buff.Write(bb[:n])
+			if err != nil {
+				return nil, ErrRequestBodyRead
+			}
+		}
+
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, errors.Join(err, ErrBodyReaderFailure)
+		}
+	}
+
+	return buff.Bytes(), nil
+}

--- a/pkg/server/internal/app/jsonutil/limited_body_reader.go
+++ b/pkg/server/internal/app/jsonutil/limited_body_reader.go
@@ -7,64 +7,103 @@ import (
 )
 
 // RequestBodyLimit1GB defines the maximum allowed size for request bodies (1GB).
+
 const RequestBodyLimit1GB = 1000 * 1024 * 1024
 
 var (
+
 	// ErrRequestBodyRead is returned when there's an error reading the request body.
+
 	ErrRequestBodyRead = errors.New("failed to read request body")
 
 	// ErrRequestBodyTooLarge is returned when the request body exceeds the size limit.
+
 	ErrRequestBodyTooLarge = errors.New("request body too large")
 
 	// ErrBodyReaderFailure is returned when the body reader fails unexpectedly,
+
 	// without returning ErrRequestBodyRead or ErrRequestBodyTooLarge.
+
 	ErrBodyReaderFailure = errors.New("unexpected failure while reading request body")
 )
 
 // LimitedBodyReader is a struct that reads and processes data from an io.Reader
+
 // with a specified limit on the maximum number of bytes that can be read.
+
 // It helps manage reading large request bodies by ensuring the data doesn't
+
 // exceed a predefined size limit.
+
 type LimitedBodyReader struct {
-	Body      io.Reader // The reader that provides the data to be read
-	ReadLimit int64     // The maximum number of bytes that can be read
+	Body io.Reader // The reader that provides the data to be read
+
+	ReadLimit int64 // The maximum number of bytes that can be read
+
 }
 
 // Read reads data from the LimitedBodyReader's io.Reader and returns the data as a byte slice.
+
 // It will read chunks of data from the body and accumulate them until the read limit is reached
+
 // or until the end of the body is encountered. If the read limit is exceeded, it returns an error.
+
 // If the reading or writing to the buffer fails, an error is returned.
+
 //
+
 // The function reads the data in chunks of 64KB (defined by the buffer size),
+
 // ensuring that no more than the allowed `ReadLimit` bytes are read.
+
 func (l *LimitedBodyReader) Read() ([]byte, error) {
+
 	reader := io.LimitReader(l.Body, l.ReadLimit+1)
+
 	buff := bytes.NewBuffer(nil)
+
 	bb := make([]byte, 64*1024)
 
 	var read int64
 
 	for {
+
 		n, err := reader.Read(bb)
+
 		if n > 0 {
+
 			read += int64(n)
+
 			if read > l.ReadLimit {
+
 				return nil, ErrRequestBodyTooLarge
+
 			}
 
 			_, err := buff.Write(bb[:n])
+
 			if err != nil {
+
 				return nil, ErrRequestBodyRead
+
 			}
+
 		}
 
 		if err != nil {
+
 			if errors.Is(err, io.EOF) {
+
 				break
+
 			}
+
 			return nil, errors.Join(err, ErrBodyReaderFailure)
+
 		}
+
 	}
 
 	return buff.Bytes(), nil
+
 }

--- a/pkg/server/internal/app/jsonutil/limited_body_reader.go
+++ b/pkg/server/internal/app/jsonutil/limited_body_reader.go
@@ -7,103 +7,58 @@ import (
 )
 
 // RequestBodyLimit1GB defines the maximum allowed size for request bodies (1GB).
-
 const RequestBodyLimit1GB = 1000 * 1024 * 1024
 
 var (
-
 	// ErrRequestBodyRead is returned when there's an error reading the request body.
-
 	ErrRequestBodyRead = errors.New("failed to read request body")
-
 	// ErrRequestBodyTooLarge is returned when the request body exceeds the size limit.
-
 	ErrRequestBodyTooLarge = errors.New("request body too large")
-
 	// ErrBodyReaderFailure is returned when the body reader fails unexpectedly,
-
 	// without returning ErrRequestBodyRead or ErrRequestBodyTooLarge.
-
 	ErrBodyReaderFailure = errors.New("unexpected failure while reading request body")
 )
 
 // LimitedBodyReader is a struct that reads and processes data from an io.Reader
-
 // with a specified limit on the maximum number of bytes that can be read.
-
 // It helps manage reading large request bodies by ensuring the data doesn't
-
 // exceed a predefined size limit.
-
 type LimitedBodyReader struct {
 	Body io.Reader // The reader that provides the data to be read
-
 	ReadLimit int64 // The maximum number of bytes that can be read
-
 }
 
 // Read reads data from the LimitedBodyReader's io.Reader and returns the data as a byte slice.
-
 // It will read chunks of data from the body and accumulate them until the read limit is reached
-
 // or until the end of the body is encountered. If the read limit is exceeded, it returns an error.
-
 // If the reading or writing to the buffer fails, an error is returned.
-
 //
-
 // The function reads the data in chunks of 64KB (defined by the buffer size),
-
 // ensuring that no more than the allowed `ReadLimit` bytes are read.
-
 func (l *LimitedBodyReader) Read() ([]byte, error) {
-
 	reader := io.LimitReader(l.Body, l.ReadLimit+1)
-
 	buff := bytes.NewBuffer(nil)
-
 	bb := make([]byte, 64*1024)
-
 	var read int64
 
 	for {
-
 		n, err := reader.Read(bb)
-
 		if n > 0 {
-
 			read += int64(n)
-
 			if read > l.ReadLimit {
-
 				return nil, ErrRequestBodyTooLarge
-
 			}
-
 			_, err := buff.Write(bb[:n])
-
 			if err != nil {
-
 				return nil, ErrRequestBodyRead
-
 			}
-
 		}
-
 		if err != nil {
-
 			if errors.Is(err, io.EOF) {
-
 				break
-
 			}
-
 			return nil, errors.Join(err, ErrBodyReaderFailure)
-
 		}
-
 	}
-
 	return buff.Bytes(), nil
-
 }

--- a/pkg/server/internal/app/jsonutil/limited_body_reader.go
+++ b/pkg/server/internal/app/jsonutil/limited_body_reader.go
@@ -9,6 +9,9 @@ import (
 // RequestBodyLimit1GB defines the maximum allowed size for request bodies (1GB).
 const RequestBodyLimit1GB = 1000 * 1024 * 1024
 
+// chunkSize defines the size of chunks to use when reading request bodies (64KB).
+const chunkSize = 64 * 1024
+
 var (
 	// ErrRequestBodyRead is returned when there's an error reading the request body.
 	ErrRequestBodyRead = errors.New("failed to read request body")
@@ -38,7 +41,7 @@ type LimitedBodyReader struct {
 func (l *LimitedBodyReader) Read() ([]byte, error) {
 	reader := io.LimitReader(l.Body, l.ReadLimit+1)
 	buff := bytes.NewBuffer(nil)
-	bb := make([]byte, 64*1024)
+	bb := make([]byte, chunkSize)
 	var read int64
 
 	for {

--- a/pkg/server/internal/app/jsonutil/limited_body_reader_test.go
+++ b/pkg/server/internal/app/jsonutil/limited_body_reader_test.go
@@ -11,132 +11,82 @@ import (
 )
 
 func TestLimitedBodyReader_NegativeScenarios(t *testing.T) {
-
 	tests := map[string]struct {
 		name string
-
 		body io.Reader
-
 		readLimit int64
-
 		expectError error
 	}{
-
 		"body exceeds limit": {
-
 			body: strings.NewReader(strings.Repeat("A", 1025)),
-
 			readLimit: 1024,
-
 			expectError: jsonutil.ErrRequestBodyTooLarge,
 		},
-
 		"error during body read": {
-
 			body: &readerAlwaysFailureStub{},
-
 			readLimit: 1024,
-
 			expectError: jsonutil.ErrBodyReaderFailure,
 		},
 	}
 
 	for name, tc := range tests {
-
 		t.Run(name, func(t *testing.T) {
-
 			// given:
-
 			reader := &jsonutil.LimitedBodyReader{
-
 				Body: tc.body,
-
 				ReadLimit: tc.readLimit,
 			}
 
 			// when:
-
 			data, err := reader.Read()
 
 			// then:
-
 			require.ErrorIs(t, err, tc.expectError)
-
 			require.Nil(t, data)
-
 		})
-
 	}
-
 }
 
 func TestLimitedBodyReader_PositiveScenarios(t *testing.T) {
-
 	tests := map[string]struct {
 		name string
-
 		body io.Reader
-
 		readLimit int64
-
 		expectedData []byte
 	}{
-
 		"valid small body": {
-
 			body: strings.NewReader("hello world"),
-
 			readLimit: 1024,
-
 			expectedData: []byte("hello world"),
 		},
-
 		"empty body": {
-
 			body: strings.NewReader(""),
-
 			readLimit: 1024,
-
 			expectedData: nil,
 		},
-
 		"body exactly at limit": {
-
 			body: strings.NewReader(strings.Repeat("A", 1024)),
-
 			readLimit: 1024,
-
 			expectedData: []byte(strings.Repeat("A", 1024)),
 		},
 	}
 
 	for name, tc := range tests {
-
 		t.Run(name, func(t *testing.T) {
-
 			// given:
-
 			reader := &jsonutil.LimitedBodyReader{
-
 				Body: tc.body,
-
 				ReadLimit: tc.readLimit,
 			}
 
 			// when:
-
 			data, err := reader.Read()
 
 			// then:
-
 			require.NoError(t, err)
-
 			require.EqualValues(t, tc.expectedData, data)
-
 		})
-
 	}
-
 }
 
 type readerAlwaysFailureStub struct{}

--- a/pkg/server/internal/app/jsonutil/limited_body_reader_test.go
+++ b/pkg/server/internal/app/jsonutil/limited_body_reader_test.go
@@ -12,19 +12,19 @@ import (
 
 func TestLimitedBodyReader_NegativeScenarios(t *testing.T) {
 	tests := map[string]struct {
-		name string
-		body io.Reader
-		readLimit int64
+		name        string
+		body        io.Reader
+		readLimit   int64
 		expectError error
 	}{
 		"body exceeds limit": {
-			body: strings.NewReader(strings.Repeat("A", 1025)),
-			readLimit: 1024,
+			body:        strings.NewReader(strings.Repeat("A", 1025)),
+			readLimit:   1024,
 			expectError: jsonutil.ErrRequestBodyTooLarge,
 		},
 		"error during body read": {
-			body: &readerAlwaysFailureStub{},
-			readLimit: 1024,
+			body:        &readerAlwaysFailureStub{},
+			readLimit:   1024,
 			expectError: jsonutil.ErrBodyReaderFailure,
 		},
 	}
@@ -33,7 +33,7 @@ func TestLimitedBodyReader_NegativeScenarios(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// given:
 			reader := &jsonutil.LimitedBodyReader{
-				Body: tc.body,
+				Body:      tc.body,
 				ReadLimit: tc.readLimit,
 			}
 
@@ -49,24 +49,24 @@ func TestLimitedBodyReader_NegativeScenarios(t *testing.T) {
 
 func TestLimitedBodyReader_PositiveScenarios(t *testing.T) {
 	tests := map[string]struct {
-		name string
-		body io.Reader
-		readLimit int64
+		name         string
+		body         io.Reader
+		readLimit    int64
 		expectedData []byte
 	}{
 		"valid small body": {
-			body: strings.NewReader("hello world"),
-			readLimit: 1024,
+			body:         strings.NewReader("hello world"),
+			readLimit:    1024,
 			expectedData: []byte("hello world"),
 		},
 		"empty body": {
-			body: strings.NewReader(""),
-			readLimit: 1024,
+			body:         strings.NewReader(""),
+			readLimit:    1024,
 			expectedData: nil,
 		},
 		"body exactly at limit": {
-			body: strings.NewReader(strings.Repeat("A", 1024)),
-			readLimit: 1024,
+			body:         strings.NewReader(strings.Repeat("A", 1024)),
+			readLimit:    1024,
 			expectedData: []byte(strings.Repeat("A", 1024)),
 		},
 	}
@@ -75,7 +75,7 @@ func TestLimitedBodyReader_PositiveScenarios(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// given:
 			reader := &jsonutil.LimitedBodyReader{
-				Body: tc.body,
+				Body:      tc.body,
 				ReadLimit: tc.readLimit,
 			}
 

--- a/pkg/server/internal/app/jsonutil/limited_body_reader_test.go
+++ b/pkg/server/internal/app/jsonutil/limited_body_reader_test.go
@@ -1,0 +1,94 @@
+package jsonutil_test
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/4chain-ag/go-overlay-services/pkg/server/internal/app/jsonutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitedBodyReader_NegativeScenarios(t *testing.T) {
+	tests := map[string]struct {
+		name        string
+		body        io.Reader
+		readLimit   int64
+		expectError error
+	}{
+		"body exceeds limit": {
+			body:        strings.NewReader(strings.Repeat("A", 1025)),
+			readLimit:   1024,
+			expectError: jsonutil.ErrRequestBodyTooLarge,
+		},
+		"error during body read": {
+			body:        &readerAlwaysFailureStub{},
+			readLimit:   1024,
+			expectError: jsonutil.ErrBodyReaderFailure,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			reader := &jsonutil.LimitedBodyReader{
+				Body:      tc.body,
+				ReadLimit: tc.readLimit,
+			}
+
+			// when:
+			data, err := reader.Read()
+
+			// then:
+			require.ErrorIs(t, err, tc.expectError)
+			require.Nil(t, data)
+		})
+	}
+}
+
+func TestLimitedBodyReader_PositiveScenarios(t *testing.T) {
+	tests := map[string]struct {
+		name         string
+		body         io.Reader
+		readLimit    int64
+		expectedData []byte
+	}{
+		"valid small body": {
+			body:         strings.NewReader("hello world"),
+			readLimit:    1024,
+			expectedData: []byte("hello world"),
+		},
+		"empty body": {
+			body:         strings.NewReader(""),
+			readLimit:    1024,
+			expectedData: nil,
+		},
+		"body exactly at limit": {
+			body:         strings.NewReader(strings.Repeat("A", 1024)),
+			readLimit:    1024,
+			expectedData: []byte(strings.Repeat("A", 1024)),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// given:
+			reader := &jsonutil.LimitedBodyReader{
+				Body:      tc.body,
+				ReadLimit: tc.readLimit,
+			}
+
+			// when:
+			data, err := reader.Read()
+
+			// then:
+			require.NoError(t, err)
+			require.EqualValues(t, tc.expectedData, data)
+		})
+	}
+}
+
+type readerAlwaysFailureStub struct{}
+
+func (*readerAlwaysFailureStub) Read(p []byte) (n int, err error) { return 0, errors.New("read error") }

--- a/pkg/server/internal/app/jsonutil/limited_body_reader_test.go
+++ b/pkg/server/internal/app/jsonutil/limited_body_reader_test.go
@@ -11,82 +11,132 @@ import (
 )
 
 func TestLimitedBodyReader_NegativeScenarios(t *testing.T) {
+
 	tests := map[string]struct {
-		name        string
-		body        io.Reader
-		readLimit   int64
+		name string
+
+		body io.Reader
+
+		readLimit int64
+
 		expectError error
 	}{
+
 		"body exceeds limit": {
-			body:        strings.NewReader(strings.Repeat("A", 1025)),
-			readLimit:   1024,
+
+			body: strings.NewReader(strings.Repeat("A", 1025)),
+
+			readLimit: 1024,
+
 			expectError: jsonutil.ErrRequestBodyTooLarge,
 		},
+
 		"error during body read": {
-			body:        &readerAlwaysFailureStub{},
-			readLimit:   1024,
+
+			body: &readerAlwaysFailureStub{},
+
+			readLimit: 1024,
+
 			expectError: jsonutil.ErrBodyReaderFailure,
 		},
 	}
 
 	for name, tc := range tests {
+
 		t.Run(name, func(t *testing.T) {
+
 			// given:
+
 			reader := &jsonutil.LimitedBodyReader{
-				Body:      tc.body,
+
+				Body: tc.body,
+
 				ReadLimit: tc.readLimit,
 			}
 
 			// when:
+
 			data, err := reader.Read()
 
 			// then:
+
 			require.ErrorIs(t, err, tc.expectError)
+
 			require.Nil(t, data)
+
 		})
+
 	}
+
 }
 
 func TestLimitedBodyReader_PositiveScenarios(t *testing.T) {
+
 	tests := map[string]struct {
-		name         string
-		body         io.Reader
-		readLimit    int64
+		name string
+
+		body io.Reader
+
+		readLimit int64
+
 		expectedData []byte
 	}{
+
 		"valid small body": {
-			body:         strings.NewReader("hello world"),
-			readLimit:    1024,
+
+			body: strings.NewReader("hello world"),
+
+			readLimit: 1024,
+
 			expectedData: []byte("hello world"),
 		},
+
 		"empty body": {
-			body:         strings.NewReader(""),
-			readLimit:    1024,
+
+			body: strings.NewReader(""),
+
+			readLimit: 1024,
+
 			expectedData: nil,
 		},
+
 		"body exactly at limit": {
-			body:         strings.NewReader(strings.Repeat("A", 1024)),
-			readLimit:    1024,
+
+			body: strings.NewReader(strings.Repeat("A", 1024)),
+
+			readLimit: 1024,
+
 			expectedData: []byte(strings.Repeat("A", 1024)),
 		},
 	}
 
 	for name, tc := range tests {
+
 		t.Run(name, func(t *testing.T) {
+
 			// given:
+
 			reader := &jsonutil.LimitedBodyReader{
-				Body:      tc.body,
+
+				Body: tc.body,
+
 				ReadLimit: tc.readLimit,
 			}
 
 			// when:
+
 			data, err := reader.Read()
 
 			// then:
+
 			require.NoError(t, err)
+
 			require.EqualValues(t, tc.expectedData, data)
+
 		})
+
 	}
+
 }
 
 type readerAlwaysFailureStub struct{}

--- a/pkg/server/noop_engine.go
+++ b/pkg/server/noop_engine.go
@@ -3,10 +3,14 @@ package server
 import (
 	"context"
 
+	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/4chain-ag/go-overlay-services/pkg/core/engine"
 	"github.com/4chain-ag/go-overlay-services/pkg/core/gasp/core"
 	"github.com/bsv-blockchain/go-sdk/overlay"
 	"github.com/bsv-blockchain/go-sdk/overlay/lookup"
+	"github.com/bsv-blockchain/go-sdk/transaction"
+
+
 )
 
 // NoopEngineProvider is a custom test overlay engine implementation. This is only a temporary solution and will be removed
@@ -106,6 +110,11 @@ func (*NoopEngineProvider) GetDocumentationForLookupServiceProvider(provider str
 // GetDocumentationForTopicManager is a no-op call that always returns an empty string with nil error.
 func (*NoopEngineProvider) GetDocumentationForTopicManager(provider string) (string, error) {
 	return "noop_engine_topic_manager_doc", nil
+}
+
+// HandleNewMerkleProof is a no-op implementation that fulfills the NewMerkleProofProvider interface.
+func (*NoopEngineProvider) HandleNewMerkleProof(ctx context.Context, txid *chainhash.Hash, proof *transaction.MerklePath) error {
+	return nil
 }
 
 // NewNoopEngineProvider returns an OverlayEngineProvider implementation

--- a/pkg/server/noop_engine.go
+++ b/pkg/server/noop_engine.go
@@ -3,14 +3,12 @@ package server
 import (
 	"context"
 
-	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/4chain-ag/go-overlay-services/pkg/core/engine"
 	"github.com/4chain-ag/go-overlay-services/pkg/core/gasp/core"
+	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/overlay"
 	"github.com/bsv-blockchain/go-sdk/overlay/lookup"
 	"github.com/bsv-blockchain/go-sdk/transaction"
-
-
 )
 
 // NoopEngineProvider is a custom test overlay engine implementation. This is only a temporary solution and will be removed


### PR DESCRIPTION
## Description of Changes
feat(arc_ingest.go) : add main arc-ingest method
feat(jsonutil.go) : add new JSON util method to parse byte array and handle errors
feat(limited_body_reader.go) : Add specified utility method to read data chunks, will be used in other command handlers such as submit_transaction.go

## Linked Issues / Tickets
Closes : Add arc-ingest command handler support #17

## Testing Procedure
feat(arc_ingest_test.go) : Add happy test and table driven tests for validation errors
feat(limited_body_reader_test) : Test cases for testing limited_body_reader.go method.

- [x] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run the linter
