### PR TITLE
Task/extend the http component to support custom route registration

### DIFF
--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -136,7 +136,7 @@ func (h *HTTP) RegisterRoute(method, path string, handler http.HandlerFunc, isAd
 	if isAdmin {
 		router = h.AdminRouter
 	}
-	
+
 	router.Add(method, path, SafeHandler(handler))
 }
 

--- a/pkg/server/http_test.go
+++ b/pkg/server/http_test.go
@@ -184,7 +184,7 @@ func Test_HTTPServer_RegisterCustomRoute(t *testing.T) {
 		}{
 			Message: "Super transaction processed successfully",
 		}
-		
+
 		jsonutil.SendHTTPResponse(w, http.StatusOK, response)
 	}
 
@@ -213,19 +213,19 @@ func Test_HTTPServer_RegisterCustomRoute(t *testing.T) {
 	var result struct {
 		Message string `json:"message"`
 	}
-	
+
 	bodyBytes, err := io.ReadAll(resp.Body)
 	require.NoError(t, err, "Failed to read response body")
-	
+
 	err = json.Unmarshal(bodyBytes, &result)
 	require.NoError(t, err, "Failed to decode JSON response")
-	
+
 	expectedMessage := "Super transaction processed successfully"
 	require.Equal(t, expectedMessage, result.Message)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	
+
 	done := httpAPI.StartWithGracefulShutdown(ctx)
 	select {
 	case <-done:


### PR DESCRIPTION
## Description of Changes

- Add RegisterRoute method to handle custom endpoints to the HTTP server.
- Add RegisterMiddleware method to allow custom middleware added to the HTTP 
server.
- Replace fiber.Handlers in HTTP struct with standard HTTP middleware
- 

## Linked Issues / Tickets

Closes [TASK] Extend the HTTP component to support custom route registration
#42

## Testing Procedure

- Add test file for custom route creation. Creates a custom route registration and processes responses for validation.

- [x] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run the linter
