### PR TITLE
[Sync] Update project files from source repository (0f07170)

### DIFF
--- a/.github/actions/warm-cache/action.yml
+++ b/.github/actions/warm-cache/action.yml
@@ -267,7 +267,7 @@ runs:
     # ────────────────────────────────────────────────────────────────────────────
     - name: 📥 Full checkout for module download (module cache miss)
       if: steps.setup-go.outputs.module-cache-hit != 'true'
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 
@@ -306,7 +306,7 @@ runs:
     # ────────────────────────────────────────────────────────────────────────────
     - name: 📥 Full checkout for build warming (module hit, build miss)
       if: steps.setup-go.outputs.module-cache-hit == 'true' && steps.setup-go.outputs.build-cache-hit != 'true'
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
       #    uses a compiled language
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -77,6 +77,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable the upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
        &nbsp;&nbsp;&nbsp;&nbsp; <code>Quality</code> &nbsp;&nbsp;
     </td>
     <td align="left">
-       <a href="https://goreportcard.com/report/github.com/bsv-blockchain/go-overlay-services"><img src="https://goreportcard.com/badge/github.com/bsv-blockchain/go-overlay-services?style=flat-square" alt="Go Report"></a>
        <a href="https://codecov.io/gh/bsv-blockchain/go-overlay-services"><img src="https://codecov.io/gh/bsv-blockchain/go-overlay-services/branch/main/graph/badge.svg?style=flat-square" alt="Coverage"></a>
     </td>
   </tr>


### PR DESCRIPTION
## What Changed

* Updated `actions/checkout` action from `v7.0.0` (commit `9c091bb`) to `v7.0.1` (commit `3d3c42e`) in two locations within `.github/actions/warm-cache/action.yml`
* Updated `github/codeql-action/init` from `v4.37.2` (commit `e0647621`) to `v4.37.3` (commit `e4fba868`) in `.github/workflows/codeql-analysis.yml`
* Updated `github/codeql-action/autobuild` from `v4.37.2` (commit `e0647621`) to `v4.37.3` (commit `e4fba868`) in `.github/workflows/codeql-analysis.yml`
* Updated `github/codeql-action/analyze` from `v4.37.2` (commit `e0647621`) to `v4.37.3` (commit `e4fba868`) in `.github/workflows/codeql-analysis.yml`
* Updated `github/codeql-action/upload-sarif` from `v4.37.2` (commit `e0647621`) to `v4.37.3` (commit `e4fba868`) in `.github/workflows/scorecard.yml`

## Why It Was Necessary

* Keeping GitHub Actions dependencies up to date ensures security patches and bug fixes are applied
* Patch version updates for these actions typically include stability improvements and security fixes
* Regular dependency updates reduce technical debt and maintain CI/CD pipeline reliability

## Testing Performed

* CI/CD workflows will automatically use the updated action versions on the next workflow execution
* The warm-cache action checkout steps will validate with the new v7.0.1 version during cache miss scenarios
* CodeQL analysis and Scorecard workflows will execute with the updated v4.37.3 actions to verify functionality

## Impact / Risk

* **Breaking Change**: None - these are patch version updates with backward compatibility
* **Risk**: Very low - patch updates typically contain only bug fixes and security improvements
* **CI/CD Impact**: No expected changes to workflow behavior or execution time

<!-- go-broadcast-metadata
group:
  id: bsv-blockchain-services
  name: bsv-blockchain-services
diff_info:
  staged_repo_available: true
  changed_files_count: 3
  files_with_original_content: 3
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 0f0717087ae0c640cd7648815a15736f770debaf
  target_repo: bsv-blockchain/go-overlay-services
  sync_commit: 28bd9924180bad1eddf94c92440e00273bbcd318
  sync_time: 2026-07-23T09:09:57-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 731
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 1360
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 402
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 0
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 627
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 494
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1478
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 2
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 1376
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 343
performance:
  total_files: 102
-->
